### PR TITLE
:building_construction: Reduce the reexport exposure for better dev exp

### DIFF
--- a/off_chain/scope-cli/src/config/scope_config.rs
+++ b/off_chain/scope-cli/src/config/scope_config.rs
@@ -37,8 +37,8 @@ impl ScopeConfig {
 mod tests {
     use super::*;
     use crate::config::utils::remove_whitespace;
+    use scope::anchor_lang::prelude::Pubkey;
     use scope::utils::OracleType;
-    use scope::Pubkey;
     use std::num::NonZeroU64;
     use std::str::FromStr;
 

--- a/off_chain/scope-cli/src/config/token_config.rs
+++ b/off_chain/scope-cli/src/config/token_config.rs
@@ -1,8 +1,8 @@
 use std::num::NonZeroU64;
 
 use super::utils::serde_string;
+use scope::anchor_lang::prelude::Pubkey;
 use scope::utils::OracleType;
-use scope::Pubkey;
 use serde::{Deserialize, Serialize};
 
 /// Configuration of the tokens

--- a/off_chain/scope-cli/src/oracle_helpers/mod.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/mod.rs
@@ -12,7 +12,7 @@ use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_sdk::clock;
 use anyhow::Result;
 use scope::utils::OracleType;
-use scope::{DatedPrice, Pubkey};
+use scope::{anchor_lang::prelude::Pubkey, DatedPrice};
 
 pub mod single_account_oracle;
 pub mod yi_token;

--- a/off_chain/scope-cli/src/oracle_helpers/single_account_oracle.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/single_account_oracle.rs
@@ -6,7 +6,7 @@ use std::fmt::{Debug, Display};
 use anchor_client::solana_client::rpc_client::RpcClient;
 use anyhow::Result;
 use scope::utils::OracleType;
-use scope::{DatedPrice, Pubkey};
+use scope::{anchor_lang::prelude::Pubkey, DatedPrice};
 
 use crate::config::TokenConfig;
 

--- a/off_chain/scope-cli/src/oracle_helpers/yi_token.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/yi_token.rs
@@ -8,9 +8,10 @@ use anyhow::{anyhow, Context, Result};
 use anchor_client::solana_client::rpc_client::RpcClient;
 use anchor_client::solana_sdk::clock;
 
+use scope::anchor_lang::{prelude::Pubkey, AccountDeserialize};
 use scope::utils::yitoken::{price_compute, YiToken};
 use scope::utils::OracleType;
-use scope::{AccountDeserialize, DatedPrice, Price, Pubkey};
+use scope::{DatedPrice, Price};
 use tracing::trace;
 
 use super::{OracleHelper, TokenEntry};

--- a/programs/scope/src/lib.rs
+++ b/programs/scope/src/lib.rs
@@ -1,13 +1,19 @@
-pub use anchor_lang::prelude::*;
-use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
-use std::convert::TryInto;
 pub mod handlers;
+pub mod program_id;
 pub mod utils;
 
-pub use handlers::*;
-pub mod program_id;
+// Reexports to deal with eventual conflicts
+pub use anchor_lang;
+pub use num_enum;
 
-pub use program_id::PROGRAM_ID;
+// Local use
+use std::convert::TryInto;
+
+use anchor_lang::prelude::*;
+use num_enum::{TryFromPrimitive, TryFromPrimitiveError};
+
+use handlers::*;
+use program_id::PROGRAM_ID;
 
 declare_id!(PROGRAM_ID);
 


### PR DESCRIPTION
Nothing fundamental in the changes but should reduce the bad suggestions from IDE when using Scope as a dependency. This still keeps all the reexport available to help to deal with dependency conflict.