### PR TITLE
:sparkles: Fresher prices for ctokens

### DIFF
--- a/programs/scope/src/handlers/handler_refresh_prices.rs
+++ b/programs/scope/src/handlers/handler_refresh_prices.rs
@@ -41,7 +41,8 @@ pub fn refresh_one_price(ctx: Context<RefreshOne>, token: usize) -> ProgramResul
     let mut oracle = ctx.accounts.oracle_prices.load_mut()?;
 
     let mut remaining_iter = ctx.remaining_accounts.iter();
-    let price = get_price(price_type, price_info, &mut remaining_iter)?;
+    let clock = Clock::get()?;
+    let price = get_price(price_type, price_info, &mut remaining_iter, &clock)?;
 
     oracle.prices[token] = price;
 
@@ -85,7 +86,8 @@ pub fn refresh_price_list(ctx: Context<RefreshList>, tokens: &[u16]) -> ProgramR
         if oracle_mappings.price_info_accounts[token_idx] != received_account.key() {
             return Err(ScopeError::UnexpectedAccount.into());
         }
-        match get_price(price_type, received_account, &mut accounts_iter) {
+        let clock = Clock::get()?;
+        match get_price(price_type, received_account, &mut accounts_iter, &clock) {
             Ok(price) => {
                 let to_update = oracle_prices
                     .get_mut(token_idx)

--- a/programs/scope/src/utils/mod.rs
+++ b/programs/scope/src/utils/mod.rs
@@ -7,7 +7,7 @@ pub mod yitoken;
 
 use crate::{DatedPrice, ScopeError};
 
-use anchor_lang::prelude::{AccountInfo, Clock, Context, ProgramResult, SolanaSysvar};
+use anchor_lang::prelude::{AccountInfo, Clock, Context, ProgramResult};
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 use serde::{Deserialize, Serialize};
 
@@ -44,6 +44,7 @@ pub fn get_price<'a, 'b>(
     price_type: OracleType,
     base_account: &AccountInfo,
     extra_accounts: &mut impl Iterator<Item = &'b AccountInfo<'a>>,
+    clock: &Clock,
 ) -> crate::Result<DatedPrice>
 where
     'a: 'b,
@@ -53,8 +54,8 @@ where
         OracleType::SwitchboardV1 => switchboard_v1::get_price(base_account),
         OracleType::SwitchboardV2 => switchboard_v2::get_price(base_account),
         OracleType::YiToken => yitoken::get_price(base_account, extra_accounts),
-        OracleType::CToken => ctokens::get_price(base_account),
-        OracleType::SplStake => spl_stake::get_price(base_account, Clock::get()?),
+        OracleType::CToken => ctokens::get_price(base_account, clock),
+        OracleType::SplStake => spl_stake::get_price(base_account, clock),
     }
 }
 

--- a/programs/scope/src/utils/spl_stake.rs
+++ b/programs/scope/src/utils/spl_stake.rs
@@ -13,7 +13,7 @@ const DECIMALS: u32 = 15u32;
 // Gives the price of 1 staked SOL in SOL
 pub fn get_price(
     stake_pool_account_info: &AccountInfo,
-    current_clock: Clock,
+    current_clock: &Clock,
 ) -> Result<DatedPrice> {
     let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_account_info.data.borrow())
         .map_err(|_| ScopeError::UnexpectedAccount)?;


### PR DESCRIPTION
On ctokens prices are sometimes not up-to-date as the reserve account is refreshed only when operations are performed (deposit withdraw...). However, it is possible to refresh the rate manually to have the current price of the token before accessing the reserve.