### PR TITLE
🚑 Rework switchboard v2 price validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -681,6 +681,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2366,7 +2381,7 @@ dependencies = [
  "log",
  "mime",
  "mime_guess",
- "quick-error",
+ "quick-error 1.2.3",
  "rand 0.8.5",
  "safemem",
  "tempfile",
@@ -2788,6 +2803,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
+dependencies = [
+ "bit-set",
+ "bitflags",
+ "byteorder",
+ "lazy_static",
+ "num-traits",
+ "quick-error 2.0.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+]
+
+[[package]]
 name = "pyth-client"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2807,6 +2842,12 @@ name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-protobuf"
@@ -2904,6 +2945,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
  "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
+dependencies = [
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -3140,6 +3190,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2cc38e8fa666e2de3c4aba7edeb5ffc5246c1c2ed0e3d17e560aeeba736b23f"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+dependencies = [
+ "fnv",
+ "quick-error 1.2.3",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3184,6 +3246,7 @@ dependencies = [
  "anchor-spl 0.20.1",
  "cfg-if 1.0.0",
  "num_enum",
+ "proptest",
  "pyth-client",
  "serde",
  "solend-program",
@@ -4823,6 +4886,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/programs/scope/Cargo.toml
+++ b/programs/scope/Cargo.toml
@@ -33,3 +33,6 @@ solend-program = { git = "https://github.com/solendprotocol/solana-program-libra
     "no-entrypoint",
 ] }
 spl-stake-pool = { version = "0.6.3", features = ["no-entrypoint"] }
+
+[dev-dependencies]
+proptest = "1.0"

--- a/programs/scope/proptest-regressions/utils/switchboard_v2.txt
+++ b/programs/scope/proptest-regressions/utils/switchboard_v2.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 68ec7556ff8ca4d6ce7749e19470f7fd91331e1953afc4a4a3d951534b399d0c # shrinks to mantissa = 1951328795563237400, scale = 12

--- a/programs/scope/src/utils/switchboard_v2.rs
+++ b/programs/scope/src/utils/switchboard_v2.rs
@@ -1,11 +1,14 @@
 use std::cmp::{max, min};
 
 use anchor_lang::prelude::*;
+use anchor_lang::solana_program::log::sol_log;
+use switchboard_v2::decimal::SwitchboardDecimal;
 use switchboard_v2::AggregatorAccountData;
 
 use crate::{DatedPrice, Price, Result, ScopeError};
 
-const MIN_NUM_SUCCESS: u32 = 3u32;
+const MAX_EXPONENT: u32 = 10;
+
 const MIN_CONFIDENCE_PERCENTAGE: u64 = 2u64;
 const CONFIDENCE_FACTOR: u64 = 100 / MIN_CONFIDENCE_PERCENTAGE;
 
@@ -13,64 +16,45 @@ pub fn get_price(switchboard_feed_info: &AccountInfo) -> Result<DatedPrice> {
     let feed = AggregatorAccountData::new(switchboard_feed_info)
         .map_err(|_| ScopeError::SwitchboardV2Error)?;
 
-    let price_switchboard_desc = feed
-        .get_result()
-        .map_err(|_| ScopeError::SwitchboardV2Error)?;
-    if price_switchboard_desc.mantissa < 0 {
-        msg!("Switchboard oracle price is negative which is not allowed");
-        return Err(ScopeError::PriceNotValid.into());
-    }
-    let price: u64 = price_switchboard_desc
-        .mantissa
-        .try_into()
-        .map_err(|_| ScopeError::MathOverflow)?;
-    let exp: u32 = price_switchboard_desc.scale;
-    let slot = feed.latest_confirmed_round.round_open_slot;
-    let stdev_mantissa = feed.latest_confirmed_round.std_deviation.mantissa;
-    let stdev_scale = feed.latest_confirmed_round.std_deviation.scale;
-    validate_valid_price(
+    let price_switchboard_desc = feed.get_result().map_err(|e| {
+        msg!(
+            "Switchboard v2 get result from feed {} failed with {:#?}",
+            switchboard_feed_info.key().to_string(),
+            e
+        );
+        ScopeError::SwitchboardV2Error
+    })?;
+
+    let price: Price = price_switchboard_desc.try_into()?;
+
+    if !cfg!(feature = "skip_price_validation") {
+        let stdev_mantissa = feed.latest_confirmed_round.std_deviation.mantissa;
+        let stdev_scale = feed.latest_confirmed_round.std_deviation.scale;
+        if validate_confidence(
+            price.value,
+            price_switchboard_desc.scale,
+            stdev_mantissa,
+            stdev_scale,
+        )
+        .is_err()
+        {
+            // Using sol log because with exactly 5 parameters, msg! expect u64s.
+            sol_log(&format!("Validation of confidence interval for switchboard v2 feed {} failed. Price: {:?}, stdev_mantissa: {:?}, stdev_scale: {:?}",
+             switchboard_feed_info.key(),
+              price,
+              stdev_mantissa,
+              stdev_scale));
+            return Err(ScopeError::SwitchboardV2Error.into());
+        }
+    };
+
+    let last_updated_slot = feed.latest_confirmed_round.round_open_slot;
+
+    Ok(DatedPrice {
         price,
-        exp,
-        slot,
-        feed.min_oracle_results,
-        feed.latest_confirmed_round.num_success,
-        stdev_mantissa,
-        stdev_scale,
-    )
-}
-
-pub fn validate_valid_price(
-    price: u64,
-    exp: u32,
-    slot: u64,
-    min_oracle_results: u32,
-    num_success: u32,
-    stdev_mantissa: i128,
-    stdev_scale: u32,
-) -> Result<DatedPrice> {
-    let dated_price = DatedPrice {
-        price: Price {
-            value: price,
-            exp: exp.into(),
-        },
-        last_updated_slot: slot,
+        last_updated_slot,
         ..Default::default()
-    };
-    if cfg!(feature = "skip_price_validation") {
-        return Ok(dated_price);
-    };
-    validate_min_success(min_oracle_results, num_success)?;
-    validate_confidence(price, exp, stdev_mantissa, stdev_scale)?;
-
-    Ok(dated_price)
-}
-
-fn validate_min_success(min_oracle_results: u32, num_success: u32) -> Result<()> {
-    let min_num_success_for_oracle = min(min_oracle_results, MIN_NUM_SUCCESS);
-    if num_success < min_num_success_for_oracle {
-        return Err(ScopeError::PriceNotValid.into());
-    };
-    Ok(())
+    })
 }
 
 fn validate_confidence(price: u64, exp: u32, stdev_mantissa: i128, stdev_scale: u32) -> Result<()> {
@@ -102,90 +86,137 @@ fn validate_confidence(price: u64, exp: u32, stdev_mantissa: i128, stdev_scale: 
     }
 }
 
+impl TryFrom<SwitchboardDecimal> for Price {
+    type Error = ScopeError;
+
+    fn try_from(sb_decimal: SwitchboardDecimal) -> std::result::Result<Self, Self::Error> {
+        if sb_decimal.mantissa < 0 {
+            msg!("Switchboard v2 oracle price feed is negative");
+            return Err(ScopeError::PriceNotValid);
+        }
+        let (exp, value) = if sb_decimal.scale > MAX_EXPONENT {
+            // exp is capped. Remove the extra digits from the mantissa.
+            let exp_diff = sb_decimal
+                .scale
+                .checked_sub(MAX_EXPONENT)
+                .ok_or(ScopeError::MathOverflow)?;
+            let factor = 10_i128
+                .checked_pow(exp_diff)
+                .ok_or(ScopeError::MathOverflow)?;
+            // Loss of precision here is expected.
+            let value = sb_decimal.mantissa / factor;
+            (MAX_EXPONENT, value)
+        } else {
+            (sb_decimal.scale, sb_decimal.mantissa)
+        };
+        let exp: u64 = exp.into();
+        let value: u64 = value.try_into().map_err(|_| ScopeError::IntegerOverflow)?;
+        Ok(Price { value, exp })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::utils::switchboard_v2;
+    use super::*;
+    use proptest::prelude::*;
+
+    const U64_MAX: i128 = std::u64::MAX as i128;
+
+    proptest! {
+        #[test]
+        fn price_from_valid_switchboard_decimal(
+            mantissa in 0_i128..=U64_MAX,
+            scale in 0u32..=10,
+        ) {
+            let sb_decimal = SwitchboardDecimal {
+                mantissa,
+                scale,
+            };
+            let price = Price::try_from(sb_decimal).unwrap();
+            prop_assert_eq!(price.value, mantissa as u64);
+            prop_assert_eq!(price.exp, scale as u64);
+        }
+    }
+
+    proptest! {
+        #[test]
+        fn price_from_caped_switchboard_decimal(
+            mantissa in 0_i128..=U64_MAX,
+            scale in 11u32..=30,
+        ) {
+            let sb_decimal = SwitchboardDecimal {
+                mantissa,
+                scale,
+            };
+            let price = Price::try_from(sb_decimal).unwrap();
+            prop_assert_eq!(price.exp, 10);
+
+            let exp_diff = scale.checked_sub(10).unwrap();
+            let scaled_up_value = price.value as i128 * 10_i128.pow(exp_diff);
+
+            let mantissa_diff = mantissa.checked_sub(scaled_up_value).unwrap();
+            prop_assert!(mantissa_diff < 10_i128.pow(exp_diff + 1));
+        }
+    }
 
     #[test]
     fn test_valid_switchboard_v2_price() {
-        assert!(switchboard_v2::validate_valid_price(1, 1, 1, 1, 1, 0, 1).is_ok());
-    }
-
-    #[test]
-    fn test_valid_switchboard_v2_price_min_1_success_2() {
-        assert!(switchboard_v2::validate_valid_price(1, 1, 1, 1, 2, 0, 1).is_ok());
-    }
-
-    #[test]
-    fn test_valid_switchboard_v2_price_default_min_success() {
-        assert!(switchboard_v2::validate_valid_price(1, 1, 1, 4, 3, 0, 1).is_ok());
-    }
-
-    #[test]
-    fn test_invalid_switchboard_v2_price_1() {
-        assert!(switchboard_v2::validate_valid_price(1, 1, 1, 2, 1, 0, 1).is_err());
-    }
-
-    #[test]
-    fn test_invalid_switchboard_v2_price_2() {
-        assert!(switchboard_v2::validate_valid_price(1, 1, 1, 4, 2, 0, 1).is_err());
+        assert!(validate_confidence(1, 1, 0, 1).is_ok());
     }
 
     //V2 Standard Deviation Confidence Tests
     #[test]
     fn test_valid_switchboard_v2_price_stdev_1_point_99_percent() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 1999, 0).is_ok());
+        assert!(validate_confidence(100, 3, 1999, 0).is_ok());
     }
 
     #[test]
     fn test_valid_switchboard_v2_price_stdev_zero() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 0, 15).is_ok());
+        assert!(validate_confidence(100, 3, 0, 15).is_ok());
     }
 
     #[test]
     fn test_valid_switchboard_v2_price_stdev_zero_1() {
-        assert!(
-            switchboard_v2::validate_valid_price(474003240021234567, 15, 1, 1, 1, 0, 1).is_ok()
-        );
+        assert!(validate_confidence(474003240021234567, 15, 0, 1).is_ok());
     }
 
     #[test]
     fn test_valid_switchboard_v2_price_stdev_1p9percent_std_exp_larger_than_price_exp() {
-        assert!(switchboard_v2::validate_valid_price(100000, 0, 1, 1, 1, 19, 2).is_ok());
+        assert!(validate_confidence(100000, 0, 19, 2).is_ok());
     }
 
     #[test]
     fn test_valid_switchboard_v2_price_stdev_1p9_std_exp_larger_than_price_exp_8_decimals_diff() {
-        assert!(switchboard_v2::validate_valid_price(100_000_000_000, 0, 1, 1, 1, 19, 8).is_ok());
+        assert!(validate_confidence(100_000_000_000, 0, 19, 8).is_ok());
     }
 
     #[test]
     fn test_valid_switchboard_v2_price_stdev_1p9_std_exp_larger_than_price_exp_9_decimals_diff() {
-        assert!(switchboard_v2::validate_valid_price(100_000_000_000, 0, 1, 1, 1, 1, 9).is_ok());
+        assert!(validate_confidence(100_000_000_000, 0, 1, 9).is_ok());
     }
 
     #[test]
     fn test_invalid_switchboard_v2_price_stdev_2percent_std_exp_larger_than_price_exp() {
-        assert!(switchboard_v2::validate_valid_price(100000, 0, 1, 1, 1, 2, 3).is_err());
+        assert!(validate_confidence(100000, 0, 2, 3).is_err());
     }
 
     #[test]
     fn test_invalid_switchboard_v2_price_stdev_2percent_std_exp_larger_than_price_exp_2() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 20, 2).is_err());
+        assert!(validate_confidence(100, 3, 20, 2).is_err());
     }
 
     #[test]
     fn test_invalid_switchboard_v2_price_stdev_above_2percent() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 2001, 0).is_err());
+        assert!(validate_confidence(100, 3, 2001, 0).is_err());
     }
 
     #[test]
     fn test_invalid_switchboard_v2_price_stdev_above_2percent_2() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 201, 1).is_err());
+        assert!(validate_confidence(100, 3, 201, 1).is_err());
     }
 
     #[test]
     fn test_invalid_switchboard_v2_price_stdev_higher_than_price() {
-        assert!(switchboard_v2::validate_valid_price(100, 3, 1, 1, 1, 100001, 0).is_err());
+        assert!(validate_confidence(100, 3, 100001, 0).is_err());
     }
 }

--- a/tests/test_switchboard.ts
+++ b/tests/test_switchboard.ts
@@ -156,7 +156,7 @@ describe('Switchboard Scope tests', () => {
   });
   it('test_set_update_stsolusd_v2_price', async () => {
     //await testTokens[HubbleTokens.STSOLUSD].updatePrice(new Decimal('123.456789012345678'), 15);
-    await testTokens[HubbleTokens.STSOLUSD].updatePrice(new Decimal('123.456789012345'), 12);
+    await testTokens[HubbleTokens.STSOLUSD].updatePrice(new Decimal('123.4567890123'), 10);
     await program.rpc.refreshOnePrice(new BN(HubbleTokens.STSOLUSD), {
       accounts: {
         oraclePrices: oracleAccount,


### PR DESCRIPTION
- Remove all checks regarding the number of jobs/oracles contributing to a price as they are already checked by switchboard.
- Add a cap to the exponent so prices don't overflow when used in computation on hubble side
- Add prop tests for that.