### PR TITLE
Skip epoch validation in spl stake

### DIFF
--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -509,7 +509,7 @@ impl ScopeClient {
             .send();
 
         match tx_res {
-            Ok(sig) => info!(signature = %sig, "Price list refreshed successfully"),
+            Ok(sig) => info!(signature = %sig, "Prices list refreshed successfully"),
             Err(err) => {
                 warn!("Price list refresh failed: {:#?}", err);
                 bail!(err);

--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -504,11 +504,17 @@ impl ScopeClient {
 
         let tokens = tokens.to_vec();
 
-        let tx = request
+        let tx_res = request
             .args(instruction::RefreshPriceList { tokens })
-            .send()?;
+            .send();
 
-        info!(signature = %tx, "Prices list refreshed successfully");
+        match tx_res {
+            Ok(sig) => info!(signature = %sig, "Price list refreshed successfully"),
+            Err(err) => {
+                warn!("Price list refresh failed: {:#?}", err);
+                bail!(err);
+            }
+        }
 
         Ok(())
     }

--- a/programs/scope/src/utils/spl_stake.rs
+++ b/programs/scope/src/utils/spl_stake.rs
@@ -3,9 +3,6 @@ use crate::{DatedPrice, Price, Result, ScopeError};
 use anchor_lang::prelude::*;
 use anchor_lang::solana_program::borsh::try_from_slice_unchecked;
 
-#[cfg(not(feature = "skip_price_validation"))]
-use anchor_lang::solana_program::log::sol_log;
-
 use spl_stake_pool::state::StakePool;
 
 const DECIMALS: u32 = 15u32;
@@ -17,13 +14,6 @@ pub fn get_price(
 ) -> Result<DatedPrice> {
     let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_account_info.data.borrow())
         .map_err(|_| ScopeError::UnexpectedAccount)?;
-
-    #[cfg(not(feature = "skip_price_validation"))]
-    if stake_pool.last_update_epoch != current_clock.epoch {
-        // The price has not been refreshed this epoch
-        sol_log("SPL Stake account has not been refreshed in current epoch");
-        return Err(ScopeError::PriceNotValid.into());
-    }
 
     let value = scaled_rate(&stake_pool)?;
 


### PR DESCRIPTION
The goal is to always have a price even while waiting for the refresh following a new epoch as a new epoch should increase the price not reduce it.