### PR TITLE
KToken, scope bot, always get position from onchain strategy.

### DIFF
--- a/off_chain/scope-cli/src/oracle_helpers/mod.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/mod.rs
@@ -43,7 +43,7 @@ pub trait OracleHelper {
     fn get_mapping_account(&self) -> &Pubkey;
 
     /// Get the extra accounts needed for the refresh price ix
-    fn get_extra_accounts(&self) -> &[Pubkey];
+    fn get_extra_accounts(&self, rpc: Option<&RpcClient>) -> Result<Vec<Pubkey>>;
 
     /// Get max age after which a refresh must be forced.
     ///

--- a/off_chain/scope-cli/src/oracle_helpers/single_account_oracle.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/single_account_oracle.rs
@@ -44,8 +44,8 @@ impl OracleHelper for SingleAccountOracle {
         &self.oracle_account
     }
 
-    fn get_extra_accounts(&self) -> &[Pubkey] {
-        &[]
+    fn get_extra_accounts(&self, _rpc: Option<&RpcClient>) -> Result<Vec<Pubkey>> {
+        Ok(Vec::with_capacity(0))
     }
 
     fn get_max_age(&self) -> clock::Slot {

--- a/off_chain/scope-cli/src/oracle_helpers/yi_token.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/yi_token.rs
@@ -82,8 +82,8 @@ impl OracleHelper for YiOracle {
         &self.mapping
     }
 
-    fn get_extra_accounts(&self) -> &[Pubkey] {
-        &self.extra_accounts
+    fn get_extra_accounts(&self, _rpc: Option<&RpcClient>) -> Result<Vec<Pubkey>> {
+        Ok(self.extra_accounts.to_vec())
     }
 
     fn get_max_age(&self) -> clock::Slot {

--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -350,7 +350,7 @@ impl ScopeClient {
         for entry in self.tokens.values() {
             let main_mapping = entry.get_mapping_account();
             print!("{main_mapping} ");
-            let extra_accounts = entry.get_extra_accounts();
+            let extra_accounts = entry.get_extra_accounts(None)?;
             for account in extra_accounts {
                 print!("{account} ");
             }
@@ -483,8 +483,8 @@ impl ScopeClient {
                 token: token.into(),
             });
 
-        for extra in entry.get_extra_accounts() {
-            request = request.accounts(AccountMeta::new_readonly(*extra, false));
+        for extra in entry.get_extra_accounts(None)? {
+            request = request.accounts(AccountMeta::new_readonly(extra, false));
         }
 
         let tx = request.send()?;
@@ -502,6 +502,8 @@ impl ScopeClient {
             clock: Clock::id(),
         };
 
+        let rpc = self.program.rpc();
+
         let request = self.program.request();
 
         let mut request = request.accounts(refresh_account);
@@ -516,8 +518,8 @@ impl ScopeClient {
                 *entry.get_mapping_account(),
                 false,
             ));
-            for extra in entry.get_extra_accounts() {
-                request = request.accounts(AccountMeta::new_readonly(*extra, false));
+            for extra in entry.get_extra_accounts(Some(&rpc))? {
+                request = request.accounts(AccountMeta::new_readonly(extra, false));
             }
         }
 

--- a/programs/scope/src/oracles/ktokens/kamino.rs
+++ b/programs/scope/src/oracles/ktokens/kamino.rs
@@ -1,4 +1,5 @@
 use std::cell::Ref;
+use std::convert::TryInto;
 
 use anchor_lang::prelude::*;
 
@@ -29,7 +30,7 @@ pub fn get_price_per_full_share(
     if shares_issued == 0 {
         Ok(U128::from(0_u128))
     } else {
-        Ok(Decimal::from(underlying_unit(shares_decimals).as_u128())
+        Ok(Decimal::from(underlying_unit(shares_decimals))
             .try_mul(holdings)?
             .try_div(shares_issued)?
             .try_ceil()?)
@@ -104,7 +105,7 @@ fn amounts_usd_token(
 
 /// The decimal scalar for vault underlying and operations involving exchangeRate().
 fn underlying_unit(share_decimals: u64) -> U128 {
-    U128::from(10_u64.pow(share_decimals as u32))
+    ten_pow(share_decimals.try_into().unwrap())
 }
 
 fn amounts_available(strategy: &WhirlpoolStrategy) -> TokenAmounts {

--- a/third-party/switchboard/scope-price-job-example.jsonc
+++ b/third-party/switchboard/scope-price-job-example.jsonc
@@ -24,13 +24,13 @@
                 },
                 {
                     "anchorFetchTask": {
-                        "programId": "HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ", /* always mainnet here */
+                        "programId": "HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ",
                         "accountAddress": "3NJYftD5sjVfxSnUdZ1wVML8f3aC6mp1CXCL6L7TnU8C"
                     }
                 },
                 {
                     "jsonParseTask": {
-                        "path": "$.prices[?((@.index==\"42\") && (@.unix_timestamp > (${CURRENT_TIMESTAMP} - 70)))].price.value"
+                        "path": "$.prices[?((@.index=='42') && (@.unixTimestamp > (${CURRENT_TIMESTAMP} - 70)))].price.value"
                     }
                 },
                 {


### PR DESCRIPTION
For kTokens, the position pubkey stored in a strategy account can change when a rebalance happen. This update fix the bot so it provides the right position account.

Bonus: Final example of a switchboard config pointing at scope price and clean-ups in Kamino interface.