### PR TITLE
Update scope to use oracle_price instead of whirlpool price

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2410,10 +2410,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
 dependencies = [
  "num-bigint 0.2.6",
- "num-complex",
+ "num-complex 0.2.4",
  "num-integer",
  "num-iter",
- "num-rational",
+ "num-rational 0.2.4",
+ "num-traits",
+]
+
+[[package]]
+name = "num"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
+dependencies = [
+ "num-bigint 0.4.3",
+ "num-complex 0.4.2",
+ "num-integer",
+ "num-iter",
+ "num-rational 0.4.1",
  "num-traits",
 ]
 
@@ -2446,6 +2460,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
  "num-traits",
 ]
 
@@ -2489,6 +2512,18 @@ checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
 dependencies = [
  "autocfg",
  "num-bigint 0.2.6",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-bigint 0.4.3",
  "num-integer",
  "num-traits",
 ]
@@ -2692,7 +2727,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd23b938276f14057220b707937bcb42fa76dda7560e57a2da30cb52d557937"
 dependencies = [
- "num",
+ "num 0.2.1",
 ]
 
 [[package]]
@@ -3428,6 +3463,8 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "decimal-wad",
+ "num 0.4.0",
+ "num-traits",
  "num_enum",
  "proptest",
  "pyth-sdk-solana",

--- a/programs/scope/Cargo.toml
+++ b/programs/scope/Cargo.toml
@@ -12,6 +12,7 @@ name = "scope"
 no-entrypoint = []
 cpi = ["no-entrypoint"]
 skip_price_validation = []
+test-bpf = []
 
 # If none of the following is set, one will be selected based on env $CLUSTER variable
 # If $CLUSTER is not set either, default will be mainnet
@@ -23,6 +24,8 @@ mainnet = []
 anchor-lang = "0.25.0"
 anchor-spl = { version = "0.25.0", features = ["token"] }
 num_enum = "0.5.7"
+num = "0.4"
+num-traits = "0.2"
 pyth-sdk-solana = "0.4.2"
 cfg-if = "1.0.0"
 serde = "1.0.136"

--- a/programs/scope/Cargo.toml
+++ b/programs/scope/Cargo.toml
@@ -13,6 +13,7 @@ no-entrypoint = []
 cpi = ["no-entrypoint"]
 skip_price_validation = []
 test-bpf = []
+debug = []
 
 # If none of the following is set, one will be selected based on env $CLUSTER variable
 # If $CLUSTER is not set either, default will be mainnet

--- a/programs/scope/proptest-regressions/oracles/ktokens/kamino.txt
+++ b/programs/scope/proptest-regressions/oracles/ktokens/kamino.txt
@@ -1,8 +1,0 @@
-# Seeds for failure cases proptest has generated in the past. It is
-# automatically read and these particular cases re-run before any
-# novel cases are generated.
-#
-# It is recommended to check this file in to source control so that
-# everyone who runs the test benefits from these saved cases.
-cc 65ede1f39e814f8939b0ee24aa4d4ecab5dfadf64f8291e30fcb6259c34945e0 # shrinks to decimals_a = 1, decimals_b = 8, a = 10310000, b = 1
-cc 6eda3f618d253e5c80d001d53ec7bff0dfd742e0c88b3c339d031a518c38acca # shrinks to decimals_a = 10, decimals_b = 1, a = 1, b = 1

--- a/programs/scope/proptest-regressions/oracles/ktokens/kamino.txt
+++ b/programs/scope/proptest-regressions/oracles/ktokens/kamino.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 65ede1f39e814f8939b0ee24aa4d4ecab5dfadf64f8291e30fcb6259c34945e0 # shrinks to decimals_a = 1, decimals_b = 8, a = 10310000, b = 1
+cc 6eda3f618d253e5c80d001d53ec7bff0dfd742e0c88b3c339d031a518c38acca # shrinks to decimals_a = 10, decimals_b = 1, a = 1, b = 1

--- a/programs/scope/src/oracles/ktokens/kamino.rs
+++ b/programs/scope/src/oracles/ktokens/kamino.rs
@@ -476,17 +476,11 @@ mod price_utils {
         let (decimals_factor, decimals_diff) = decimals_factor(decimals_a, decimals_b)?;
         let px = U128::from(price.value);
         let (scaled_price, final_exp) = if decimals_b > decimals_a {
-            (
-                U128::from(px.checked_mul(decimals_factor).unwrap()),
-                price.exp,
-            )
+            (px.checked_mul(decimals_factor).unwrap(), price.exp)
         } else {
             // If we divide by 10 ^ (decimals_a - decimals_b) here we lose precision
             // So instead we lift the price even more (by the diff) and assume a bigger exp
-            (
-                U128::from(px),
-                price.exp.checked_add(decimals_diff).unwrap(),
-            )
+            (px, price.exp.checked_add(decimals_diff).unwrap())
         };
 
         let two_factor = pow(2, 64);
@@ -716,5 +710,14 @@ mod tests {
                 return Err(TestCaseError::Reject(Reason::from("Bad input")));
             }
         }
+    }
+
+    #[test]
+    fn test_numerical_examples() {
+        // USDH-USDC
+        // USDC-USDT
+        // SOL-STSOL
+        // USH-USDC
+        // SOL-DUST
     }
 }

--- a/programs/scope/src/oracles/ktokens/kamino.rs
+++ b/programs/scope/src/oracles/ktokens/kamino.rs
@@ -51,6 +51,9 @@ fn holdings(
     let decimals_a = strategy.token_a_mint_decimals;
     let decimals_b = strategy.token_b_mint_decimals;
 
+    // https://github.com/0xparashar/UniV3NFTOracle/blob/master/contracts/UniV3NFTOracle.sol#L27
+    // We are using the sqrt price derived from price_a and price_b
+    // instead of the whirlpool price which could be manipulated/stale
     let sqrt_price_from_oracle = price_utils::sqrt_price_from_scope_prices(
         prices.price_a.price,
         prices.price_b.price,
@@ -441,15 +444,6 @@ mod price_utils {
 
         let final_factor = pow(10, exp);
 
-        println!(
-            "a_to_b: a:{} b:{} px_a:{} px_b:{} final_factor:{} px_x*ff:{}",
-            a.value,
-            b.value,
-            px_a,
-            px_b,
-            final_factor,
-            px_a.checked_mul(final_factor).unwrap()
-        );
         let price_a_to_b = px_a
             .checked_mul(final_factor)
             .unwrap()
@@ -530,7 +524,6 @@ mod tests {
         let px = (price * 10.0_f64.pow(decimals_b as i32 - decimals_a as i32)).sqrt();
         let res = (px * 2.0_f64.powf(64.0)) as u128;
 
-        println!("calc_sqrt_price_from_float_price: {} {}", price, res);
         res
     }
 

--- a/programs/scope/src/oracles/ktokens/kamino.rs
+++ b/programs/scope/src/oracles/ktokens/kamino.rs
@@ -643,12 +643,7 @@ mod tests {
         );
     }
 
-    enum TestResult {
-        Res(f64),
-        Dismiss,
-    }
-
-    fn run_test(decimals_a: i32, decimals_b: i32, ua: i32, ub: i32) -> TestResult {
+    fn run_test(decimals_a: i32, decimals_b: i32, ua: i32, ub: i32) -> Option<f64> {
         let price_float_factor = 10_000.0;
         let fa = ua as f64 / price_float_factor; // float a
         let fb = ub as f64 / price_float_factor; // float b
@@ -664,7 +659,7 @@ mod tests {
         println!("dA: {}, dB: {}", decimals_a, decimals_b);
 
         if sa.value == 0 || sb.value == 0 {
-            return TestResult::Dismiss;
+            return None;
         }
 
         let price = fa / fb;
@@ -687,7 +682,7 @@ mod tests {
             float_actual,
             float_diff * 100.0
         );
-        TestResult::Res(float_diff)
+        Some(float_diff)
     }
 
     #[test]
@@ -698,7 +693,7 @@ mod tests {
         let a = 1;
         let b = 1048;
 
-        if let TestResult::Res(diff) = run_test(decimals_a, decimals_b, a, b) {
+        if let Some(diff) = run_test(decimals_a, decimals_b, a, b) {
             assert!(diff < 0.001);
         } else {
             println!("Test result dismissed");
@@ -715,7 +710,7 @@ mod tests {
             b in 1..200_000_000,
         ) {
 
-            if let TestResult::Res(float_diff) = run_test(decimals_a, decimals_b, a, b) {
+            if let Some(float_diff) = run_test(decimals_a, decimals_b, a, b) {
                 prop_assert!(float_diff < 0.001, "float_diff: {}", float_diff);
             } else {
                 return Err(TestCaseError::Reject(Reason::from("Bad input")));

--- a/programs/scope/src/oracles/ktokens/kamino.rs
+++ b/programs/scope/src/oracles/ktokens/kamino.rs
@@ -45,27 +45,27 @@ fn holdings(
     prices: &TokenPrices,
 ) -> ScopeResult<U128> {
     let available = amounts_available(strategy);
+
+    let decimals_a = strategy.token_a_mint_decimals;
+    let decimals_b = strategy.token_b_mint_decimals;
+
     let sqrt_price_from_oracle = price_utils::sqrt_price_from_scope_prices(
         prices.price_a.price,
         prices.price_b.price,
-        strategy.token_a_mint_decimals,
-        strategy.token_b_mint_decimals,
+        decimals_a,
+        decimals_b,
     )?;
 
     if cfg!(feature = "debug") {
-        let decimals_a = strategy.token_a_mint_decimals;
-        let decimals_b = strategy.token_b_mint_decimals;
-
         let w = calc_price_from_sqrt_price(whirlpool.sqrt_price, decimals_a, decimals_b);
         let o = calc_price_from_sqrt_price(sqrt_price_from_oracle, decimals_a, decimals_b);
         let diff = (w - o).abs() / w;
-
         msg!("o: {} w: {} d: {}%", w, o, diff * 100.0);
     }
 
     let invested = amounts_invested(position, sqrt_price_from_oracle);
-
     // We want the minimum price we would get in the event of a liquidation so ignore pending fees and pending rewards
+
     let available_usd = amounts_usd(strategy, &available, prices)?;
     let invested_usd = amounts_usd(strategy, &invested, prices)?;
 


### PR DESCRIPTION
https://github.com/0xparashar/UniV3NFTOracle/blob/master/contracts/UniV3NFTOracle.sol#L27

----

Edge case when this is a problem: whirlpool price is stale/unarbed, we trust the oracle instead to calculate the a/b distribution within the position.

Logic for the calc:

https://gist.github.com/y2kappa/326e70f72a685e2b3fe9647f0d4a5b95

<img width="717" alt="Screenshot 2022-09-24 at 15 29 28" src="https://user-images.githubusercontent.com/10101287/192117784-798f5bb8-d2ff-4b61-933b-4655d48f45eb.png">
