### PR TITLE
Remove secret key which is no longer used in env

### DIFF
--- a/off_chain/docker-bot/helm/values.yaml
+++ b/off_chain/docker-bot/helm/values.yaml
@@ -45,6 +45,6 @@ service-base-chart:
   #      value: "TRUE"
   secrets:
     keypair.json:
-    VALIDATOR_RPC_URL:
+#    VALIDATOR_RPC_URL:
   config:
     mapping.json:


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16102271/197095333-3259d433-03e1-4b23-aae9-a87259f0955a.png)

The secret fails to decrypt on the null key because we are no longer specifying it by default