### PR TITLE
General logs improvement

### DIFF
--- a/off_chain/scope-cli/src/main.rs
+++ b/off_chain/scope-cli/src/main.rs
@@ -289,9 +289,9 @@ fn crank(
 
         if num_retries_before_err == 0 {
             if old_price_is_error {
-                error!(%error_log);
+                error!(%error_log, old_prices=?scope.get_expired_prices().unwrap_or_default());
             } else {
-                warn!(%error_log);
+                warn!(%error_log, old_prices=?scope.get_expired_prices().unwrap_or_default());
             }
             num_retries_before_err = init_num_retries_before_err;
         }

--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -29,7 +29,7 @@ const MAX_REFRESH_CHUNK_SIZE: usize = 26;
 
 /// Max compute units to request
 // TODO: optimize this so the refresh lists costs less.
-const MAX_COMPUTE_UNITS: u32 = 1_300_000;
+const MAX_COMPUTE_UNITS: u32 = 1_400_000;
 
 type TokenEntryList = IntMap<u16, Box<dyn TokenEntry>>;
 pub struct ScopeClient {
@@ -539,10 +539,16 @@ impl ScopeClient {
 
         match tx_res {
             Ok(sig) => info!(signature = %sig, "Prices list refreshed successfully"),
-            Err(err) => {
-                warn!("Price list refresh failed: {:#?}", err);
-                bail!(err);
-            }
+            Err(err) => match err {
+                anchor_client::ClientError::SolanaClientError(e) => {
+                    info!("Prices list refresh failed: RPC Client error: {e:#?}");
+                    // We could `bail!` here but we want to avoid double logs,
+                }
+                _ => {
+                    warn!("Price list refresh failed: {:#?}", err);
+                    // We could `bail!` here but we want to avoid double logs,
+                }
+            },
         }
 
         Ok(())

--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -350,6 +350,20 @@ impl ScopeClient {
         Ok(())
     }
 
+    /// Return a list (label if available) of expired prices
+    pub fn get_expired_prices(&self) -> Result<Vec<String>> {
+        Ok(self
+            .get_prices_ttl()?
+            .filter_map(|(index, ttl)| {
+                if ttl > 0 {
+                    self.tokens.get(&index).map(|t| t.to_string())
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
     /// Print a list of all pubkeys that are needed for price refreshed.
     pub fn print_pubkeys(&self) -> Result<()> {
         for entry in self.tokens.values() {


### PR DESCRIPTION
- RPC errors are now printed as "info" to allow retries without alerting.
- We print which tokens are old when alerting of old prices.