### PR TITLE
⚡️ Reduce the number of CU spent on error prints.

### DIFF
--- a/programs/scope/src/handlers/handler_refresh_prices.rs
+++ b/programs/scope/src/handlers/handler_refresh_prices.rs
@@ -127,12 +127,12 @@ pub fn refresh_price_list(ctx: Context<RefreshList>, tokens: &[u16]) -> Result<(
                 *to_update = price;
                 to_update.index = token_nb;
             }
-            Err(e) => {
+            Err(_) => {
+                // Skip the error, details is already logged in get_price and formatting here cost a lot of CU
                 msg!(
-                    "Price skipped as validation failed (token {}, type {:?}, err {:?})",
+                    "Price skipped as validation failed (token {}, type {:?})",
                     token_idx,
-                    price_type,
-                    e
+                    price_type
                 );
             }
         };

--- a/programs/scope/src/oracles/pyth.rs
+++ b/programs/scope/src/oracles/pyth.rs
@@ -39,7 +39,10 @@ pub fn get_price(price_info: &AccountInfo) -> Result<DatedPrice> {
     };
 
     let price = validate_valid_price(&pyth_price, ORACLE_CONFIDENCE_FACTOR).map_err(|e| {
-        msg!("Invalid price on pyth account {}", price_info.key);
+        msg!(
+            "Confidence interval check failed on pyth account {}",
+            price_info.key
+        );
         e
     })?;
 

--- a/programs/scope/src/oracles/pyth_ema.rs
+++ b/programs/scope/src/oracles/pyth_ema.rs
@@ -21,8 +21,10 @@ const ORACLE_CONFIDENCE_FACTOR: u64 = 50; // 100% / 2%
 
 pub fn get_price(price_info: &AccountInfo) -> Result<DatedPrice> {
     let data = price_info.try_borrow_data()?;
-    let price_account = pyth_client::load_price_account(data.as_ref())
-        .map_err(|_| error!(ScopeError::PriceNotValid))?;
+    let price_account = pyth_client::load_price_account(data.as_ref()).map_err(|e| {
+        msg!("Invalid pyth price account: {}", e);
+        error!(ScopeError::PriceNotValid)
+    })?;
 
     let pyth_raw = price_account.to_price_feed(price_info.key);
 

--- a/programs/scope/src/oracles/spl_stake.rs
+++ b/programs/scope/src/oracles/spl_stake.rs
@@ -11,7 +11,10 @@ pub fn get_price(
     current_clock: &Clock,
 ) -> Result<DatedPrice> {
     let stake_pool = try_from_slice_unchecked::<StakePool>(&stake_pool_account_info.data.borrow())
-        .map_err(|_| ScopeError::UnexpectedAccount)?;
+        .map_err(|_| {
+            msg!("Provided pubkey is not a SPL Stake account");
+            ScopeError::UnexpectedAccount
+        })?;
 
     #[cfg(not(feature = "skip_price_validation"))]
     if stake_pool.last_update_epoch != current_clock.epoch {

--- a/programs/scope/src/utils/mod.rs
+++ b/programs/scope/src/utils/mod.rs
@@ -26,8 +26,10 @@ pub fn account_deserialize<T: AccountDeserialize + Discriminator>(
     }
 
     let mut data: &[u8] = &data;
-    let user: T =
-        T::try_deserialize(&mut data).map_err(|_| ScopeError::UnableToDeserializeAccount)?;
+    let user: T = T::try_deserialize(&mut data).map_err(|_| {
+        msg!("Account {:?} deserialization failed", account.key());
+        ScopeError::UnableToDeserializeAccount
+    })?;
 
     Ok(user)
 }


### PR DESCRIPTION
We had multiple occurrences of price updates failing because of the CU budget was reached when some prices were in error.

This PR removes the formating of all errors returned by the "get_price" functions and instead checks that we correctly print all errors as they happen.