### PR TITLE
Add get_slot_with_commitment function to orbit-link async trait

### DIFF
--- a/off_chain/orbit-link/src/async_client/banks_client.rs
+++ b/off_chain/orbit-link/src/async_client/banks_client.rs
@@ -90,6 +90,11 @@ impl AsyncClient for Mutex<BanksClient> {
         Ok(accounts)
     }
 
+    async fn get_slot_with_commitment(&self, _commitment: CommitmentConfig) -> Result<Slot> {
+        let mut bank = self.lock().await;
+        bank.get_root_slot().await.map_err(Into::into)
+    }
+
     async fn get_recommended_micro_lamport_fee(&self) -> Result<u64> {
         Ok(0)
     }

--- a/off_chain/orbit-link/src/async_client/mod.rs
+++ b/off_chain/orbit-link/src/async_client/mod.rs
@@ -3,8 +3,9 @@ pub mod banks_client;
 #[cfg(feature = "rpc-client")]
 pub mod rpc_client;
 
+use anchor_client::solana_sdk::commitment_config::CommitmentConfig;
 use anchor_client::solana_sdk::{
-    account::Account, hash::Hash, pubkey::Pubkey, signature::Signature,
+    account::Account, clock::Slot, hash::Hash, pubkey::Pubkey, signature::Signature,
     transaction::VersionedTransaction,
 };
 use async_trait::async_trait;
@@ -30,6 +31,8 @@ pub trait AsyncClient: Sync {
     async fn get_account(&self, pubkey: &Pubkey) -> Result<Account>;
 
     async fn get_multiple_accounts(&self, pubkeys: &[Pubkey]) -> Result<Vec<Option<Account>>>;
+
+    async fn get_slot_with_commitment(&self, commitment: CommitmentConfig) -> Result<Slot>;
 
     async fn get_recommended_micro_lamport_fee(&self) -> Result<u64>;
 }

--- a/off_chain/orbit-link/src/async_client/rpc_client.rs
+++ b/off_chain/orbit-link/src/async_client/rpc_client.rs
@@ -52,6 +52,12 @@ impl AsyncClient for RpcClient {
             .map_err(Into::into)
     }
 
+    async fn get_slot_with_commitment(&self, commitment: CommitmentConfig) -> Result<Slot> {
+        <RpcClient>::get_slot_with_commitment(self, commitment)
+            .await
+            .map_err(Into::into)
+    }
+
     async fn get_recommended_micro_lamport_fee(&self) -> Result<u64> {
         // Fixed to 10 lamports per 200_000 CU (default 1 ix transaction) for now
         // 10 * 1M / 200_000 = 50


### PR DESCRIPTION
A finalized slot to create lookup table -

```rs
    let recent_slot = client
        .client
        .get_slot_with_commitment(CommitmentConfig::finalized())
        .await
        .unwrap();
    let (create_lookup_table, table_pk) =
        solana_address_lookup_table_program::instruction::create_lookup_table(
            client.payer(),
            client.payer(),
            recent_slot,
        );
```

The banks client impl ignores the commitment parameter and always returns finalized - there is a method on the banks client to get with commitment, but it requires a context param which I couldn't figure out how to init 