### PR TITLE
Add a placeholder for the deprecated `OracleType.YiToken`

### DIFF
--- a/off_chain/scope-cli/src/oracle_helpers/mod.rs
+++ b/off_chain/scope-cli/src/oracle_helpers/mod.rs
@@ -77,5 +77,8 @@ pub async fn entry_from_config(
         | OracleType::SplStake
         | OracleType::PythEMA => Box::new(SingleAccountOracle::new(token_conf, default_max_age)),
         OracleType::KToken => Box::new(KTokenOracle::new(token_conf, default_max_age, rpc).await?),
+        OracleType::DeprecatedPlaceholder => {
+            panic!("DeprecatedPlaceholder is not a valid oracle type")
+        }
     })
 }

--- a/programs/scope/src/oracles/mod.rs
+++ b/programs/scope/src/oracles/mod.rs
@@ -29,7 +29,9 @@ pub enum OracleType {
     Pyth = 0,
     SwitchboardV1 = 1,
     SwitchboardV2 = 2,
-    // Deprecated YiToken = 3,
+    /// Deprecated (formerly YiToken)
+    // Do not remove - breaks the typescript idl codegen
+    DeprecatedPlaceholder = 3,
     /// Solend tokens
     CToken = 4,
     /// SPL Stake Pool token (like scnSol)
@@ -51,6 +53,9 @@ impl OracleType {
             OracleType::SplStake => 20000,
             OracleType::KToken => 50000,
             OracleType::PythEMA => 15000,
+            OracleType::DeprecatedPlaceholder => {
+                panic!("DeprecatedPlaceholder is not a valid oracle type")
+            }
         }
     }
 }
@@ -77,6 +82,9 @@ where
         OracleType::SplStake => spl_stake::get_price(base_account, clock),
         OracleType::KToken => ktokens::get_price(base_account, extra_accounts),
         OracleType::PythEMA => pyth_ema::get_price(base_account),
+        OracleType::DeprecatedPlaceholder => {
+            panic!("DeprecatedPlaceholder is not a valid oracle type")
+        }
     }
 }
 
@@ -96,5 +104,8 @@ pub fn validate_oracle_account(
         OracleType::SplStake => Ok(()),
         OracleType::KToken => Ok(()),
         OracleType::PythEMA => pyth::validate_pyth_price_info(price_account),
+        OracleType::DeprecatedPlaceholder => {
+            panic!("DeprecatedPlaceholder is not a valid oracle type")
+        }
     }
 }


### PR DESCRIPTION
The typescript idl codegen broke due to giving subsequent `OracleTypes` the wrong index.

See https://github.com/hubbleprotocol/hubble-common/pull/349