### PR TITLE
🩹 Fix clone mainnet tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,11 @@ print-pubkeys: $(SCOPE_CLI)
 >@ ./target/debug/scope --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) get-pubkeys --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json
 
 clone-mainnet-to-local-validator: $(SCOPE_CLI)
->@ export ORACLE_PUBKEYS="${shell CLUSTER=mainnet make -s print-pubkeys}"
+>@ export ORACLE_PUBKEYS="${shell CLUSTER=mainnet make -s print-pubkeys 2> /dev/null}"
 > solana-test-validator -r --url "https://solana-mainnet.rpc.extrnode.com" --clone $$ORACLE_PUBKEYS
 
 clone-devnet-to-local-validator:
->@ export ORACLE_PUBKEYS="${shell CLUSTER=devnet make -s print-pubkeys}"
+>@ export ORACLE_PUBKEYS="${shell CLUSTER=devnet make -s print-pubkeys 2> /dev/null}"
 > solana-test-validator -r --url "https://rpc.ankr.com/solana_devnet" --clone $$ORACLE_PUBKEYS
 
 test: test-rust test-ts

--- a/off_chain/scope-cli/src/main.rs
+++ b/off_chain/scope-cli/src/main.rs
@@ -136,15 +136,18 @@ enum Actions {
 async fn main() -> Result<()> {
     let args: Args = Args::parse();
 
-    if args.json {
-        tracing_subscriber::fmt().json().without_time().init();
-    } else if args.log_timestamps {
-        tracing_subscriber::fmt().compact().init();
-    } else {
-        tracing_subscriber::fmt().compact().without_time().init();
-    }
+    // Skip logging if only printing pubkeys
+    if !matches!(args.action, Actions::GetPubkeys { .. }) {
+        if args.json {
+            tracing_subscriber::fmt().json().without_time().init();
+        } else if args.log_timestamps {
+            tracing_subscriber::fmt().compact().init();
+        } else {
+            tracing_subscriber::fmt().compact().without_time().init();
+        }
 
-    info!("Starting with args {:#?}", args);
+        info!("Starting with args {:#?}", args);
+    }
 
     // Read keypair to sign transactions
     let payer = read_keypair_file(args.keypair).expect("Keypair file not found or invalid");

--- a/off_chain/scope-cli/src/scope_client.rs
+++ b/off_chain/scope-cli/src/scope_client.rs
@@ -1,3 +1,4 @@
+use std::collections::HashSet;
 use std::mem::size_of;
 
 use anchor_client::{
@@ -379,14 +380,18 @@ where
 
     /// Print a list of all pubkeys that are needed for price refreshed.
     pub async fn print_pubkeys(&self) -> Result<()> {
+        // Print only unique pubkeys
+        let mut pubkeys: HashSet<Pubkey> = HashSet::new();
+
         for entry in self.tokens.values() {
             let main_mapping = entry.get_mapping_account();
-            print!("{main_mapping} ");
+            pubkeys.insert(*main_mapping);
             let extra_accounts = entry.get_extra_accounts(None).await?;
             for account in extra_accounts {
-                print!("{account} ");
+                pubkeys.insert(account);
             }
         }
+        pubkeys.iter().for_each(|pk| print!("{pk} "));
         println!();
         Ok(())
     }


### PR DESCRIPTION
- Remove duplicated pubkeys
- Avoid the risk of having some build logs passed to the test validator cli
- Remove the regular logging when printing pubkey to avoid pollution of the pubkey list