### PR TITLE
Update scope admin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ keys/**/*.*
 !keys/localnet/owner.json
 .vscode/
 CLUSTER
+.cargo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3955,6 +3955,7 @@ dependencies = [
  "anchor-client",
  "anyhow",
  "async-trait",
+ "bincode",
  "clap 3.2.25",
  "futures",
  "nohash-hasher",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1654,9 +1654,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
  "percent-encoding",
 ]
@@ -3957,6 +3957,7 @@ dependencies = [
  "async-trait",
  "bincode",
  "clap 3.2.25",
+ "form_urlencoded",
  "futures",
  "nohash-hasher",
  "orbit-link",

--- a/off_chain/orbit-link/src/tx_builder.rs
+++ b/off_chain/orbit-link/src/tx_builder.rs
@@ -3,7 +3,7 @@ use anchor_client::{
     solana_sdk::{
         address_lookup_table_account::AddressLookupTableAccount,
         compute_budget::ComputeBudgetInstruction, instruction::Instruction, message::Message,
-        pubkey::Pubkey, signer::Signer, transaction::VersionedTransaction, hash::Hash,
+        pubkey::Pubkey, signer::Signer, transaction::VersionedTransaction,
     },
 };
 use base64::engine::{general_purpose::STANDARD as BS64, Engine};
@@ -138,9 +138,7 @@ where
             .await
     }
 
-    pub fn add_budget_ix(
-        mut self,
-    ) -> Self {
+    pub fn add_budget_ix(mut self) -> Self {
         let mut instructions = Vec::with_capacity(self.instructions.len() + 1);
         if let Some(ix_budget) = self.get_budget_ix() {
             instructions.push(ix_budget);
@@ -179,10 +177,7 @@ where
             .await
     }
 
-    pub fn add_budget_and_fee_ix(
-        mut self,
-        fee: u64,
-    ) -> Self {
+    pub fn add_budget_and_fee_ix(mut self, fee: u64) -> Self {
         let mut instructions = Vec::with_capacity(self.instructions.len() + 2);
 
         if let Some(ix_budget) = self.get_budget_ix() {
@@ -205,20 +200,9 @@ where
     /// The message is not signed, and the blockhash is not set allowing future signing by a multisig.
     /// Note: This is not compatible with versioned transactions yet and does not include lookup tables.
     pub fn build_raw_msg(&self) -> Vec<u8> {
-        let mut payer_option = None;
-        let payer_pubkey = self.link.payer();
-        if payer_pubkey != Pubkey::default() {
-            payer_option = Some(&payer_pubkey);
-        }
+        let payer_pubkey = self.link.payer_pubkey();
 
-        let msg = Message::new(&self.instructions, payer_option);
-        msg.serialize()
-    }
-
-    pub fn build_raw_msg_with_blockhash(&self, blockhash: &Hash) -> Vec<u8> {
-        let payer_pubkey = self.link.payer();
-
-        let msg = Message::new_with_blockhash(&self.instructions, Some(&payer_pubkey), blockhash);
+        let msg = Message::new(&self.instructions, Some(&payer_pubkey));
         msg.serialize()
     }
 
@@ -227,14 +211,6 @@ where
     /// See `build_raw_msg` for more details.
     pub fn to_base64(&self) -> String {
         let raw_msg = self.build_raw_msg();
-        BS64.encode(raw_msg)
-    }
-
-    /// Build a base64 encoded raw message from the known instructions.
-    /// using a blockhash in order to be simulatable 
-    /// See `build_raw_msg` for more details.
-    pub fn to_base64_with_blockhash(&self, blockhash: &Hash) -> String {
-        let raw_msg = self.build_raw_msg_with_blockhash(blockhash);
         BS64.encode(raw_msg)
     }
 

--- a/off_chain/scope-cli/Cargo.toml
+++ b/off_chain/scope-cli/Cargo.toml
@@ -36,3 +36,4 @@ orbit-link = { path = "../orbit-link" }
 async-trait = "0.1.51"
 futures = "0.3.18"
 bincode = "1.3.3"
+form_urlencoded = "1.2.1"

--- a/off_chain/scope-cli/Cargo.toml
+++ b/off_chain/scope-cli/Cargo.toml
@@ -35,3 +35,4 @@ nohash-hasher = "0.2.0"
 orbit-link = { path = "../orbit-link" }
 async-trait = "0.1.51"
 futures = "0.3.18"
+bincode = "1.3.3"

--- a/off_chain/scope-cli/README.md
+++ b/off_chain/scope-cli/README.md
@@ -1,0 +1,17 @@
+# CLI HELP
+
+### How to use
+- Running the following line compiles the CLI and outputs all the available commands
+`cargo run -p scope-cli -- --help`
+- Running the following line tells you what args the command expects
+`cargo run -p scope-cli -- <command-name> --help`
+
+#### Examples
+- Set admin-cached for a price_feed configuration
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message base58
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message bae64
+- Approve admin-cached for a price_feed configuration
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message base58
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message bae64

--- a/off_chain/scope-cli/README.md
+++ b/off_chain/scope-cli/README.md
@@ -8,8 +8,8 @@
 
 #### Examples
 - Set admin-cached for a price_feed configuration
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig` - to get encoded message base58
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster localnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
+`cargo run -p scope-cli -- --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster localnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to get encoded message base58
 - Approve admin-cached for a price_feed configuration
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached` - to execute
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --multisig` - to get encoded message base58
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster localnet approve-admin-cached` - to execute
+`cargo run -p scope-cli -- --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --multisig yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to get encoded message base58 and simulation base64 - for multisig 

--- a/off_chain/scope-cli/README.md
+++ b/off_chain/scope-cli/README.md
@@ -2,16 +2,14 @@
 
 ### How to use
 - Running the following line compiles the CLI and outputs all the available commands
-`cargo run -p scope-cli -- --help`
+`cargo run -p scope-cli -- help`
 - Running the following line tells you what args the command expects
-`cargo run -p scope-cli -- <command-name> --help`
+`cargo run -p scope-cli -- help <command-name>`
 
 #### Examples
 - Set admin-cached for a price_feed configuration
 `cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message base58
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message bae64
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet set-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig` - to get encoded message base58
 - Approve admin-cached for a price_feed configuration
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr` - to execute
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message base58
-`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --admin-cached yV4XWzpBQZ6bamKWaAZTPhEk3WphNZsaVqQ2msAX4Cr --multisig --base58` - to get encoded message bae64
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached` - to execute
+`cargo run -p scope-cli -- --keypair keys/localnet/owner.json --program-id HFn8GnPADiny6XqUoWE8uRPPxb29ikn4yTuPa9MF2fWJ --price-feed hubble --cluster mainnet approve-admin-cached --multisig` - to get encoded message base58

--- a/off_chain/scope-cli/src/main.rs
+++ b/off_chain/scope-cli/src/main.rs
@@ -139,6 +139,36 @@ enum Actions {
         #[clap(long, env)]
         token: u16,
     },
+
+    /// Sets the admin cached for the config
+    /// This requires admin keypair
+    #[clap()]
+    SetAdminCached {
+        /// The pubkey of the admin_cached
+        #[clap(long, env, parse(try_from_str))]
+        admin_cached: Pubkey,
+        /// If set returns a base58 encoded string instead of executing tx signing with provided keypair
+        #[clap(long, env)]
+        multisig: bool,
+        /// Wether it should return tx in base64 - useful for simulations
+        #[clap(long, env)]
+        base64: bool,
+    },
+
+    /// Approves the admin cached for the config
+    /// This requires adminc_cached keypair
+    #[clap()]
+    ApproveAdminCached {
+        /// The pubkey of the admin_cached - to become admin
+        #[clap(long, env, parse(try_from_str))]
+        admin_cached: Pubkey,
+        /// If set returns a base58 encoded string instead of executing tx signing with provided keypair
+        #[clap(long, env)]
+        multisig: bool,
+        /// Wether it should return tx in base64 - useful for simulations
+        #[clap(long, env)]
+        base64: bool,
+    },
 }
 
 #[tokio::main]
@@ -210,6 +240,16 @@ async fn main() -> Result<()> {
             }
             Actions::GetPubkeys { mapping } => get_pubkeys(&mut scope, &mapping).await,
             Actions::ResetTwap { token } => reset_twap(&scope, token).await,
+            Actions::SetAdminCached {
+                admin_cached,
+                multisig,
+                base64,
+            } => set_admin_cached(&mut scope, admin_cached, multisig, base64).await,
+            Actions::ApproveAdminCached {
+                admin_cached,
+                multisig,
+                base64,
+            } => approve_admin_cached(&mut scope, admin_cached, multisig, base64).await,
         }
     }
 }
@@ -380,4 +420,26 @@ async fn reset_twap<T: AsyncClient, S: Signer>(
     token: u16,
 ) -> Result<()> {
     scope.reset_twap_price(token).await
+}
+
+async fn set_admin_cached<T: AsyncClient, S: Signer>(
+    scope: &ScopeClient<T, S>,
+    admin_cached: Pubkey,
+    multisig: bool,
+    base64: bool,
+) -> Result<()> {
+    scope
+        .ix_set_admin_cached(admin_cached, multisig, base64)
+        .await
+}
+
+async fn approve_admin_cached<T: AsyncClient, S: Signer>(
+    scope: &ScopeClient<T, S>,
+    admin_cached: Pubkey,
+    multisig: bool,
+    base64: bool,
+) -> Result<()> {
+    scope
+        .ix_approve_admin_cached(admin_cached, multisig, base64)
+        .await
 }

--- a/programs/scope/src/handlers/handler_approve_admin_cached.rs
+++ b/programs/scope/src/handlers/handler_approve_admin_cached.rs
@@ -1,0 +1,28 @@
+use anchor_lang::{prelude::*, Accounts};
+
+use crate::oracles::check_context;
+
+#[derive(Accounts)]
+#[instruction(feed_name: String)]
+pub struct ApproveAdminCached<'info> {
+    admin_cached: Signer<'info>,
+
+    #[account(mut, seeds = [b"conf", feed_name.as_bytes()], bump, has_one = admin_cached)]
+    pub configuration: AccountLoader<'info, crate::Configuration>,
+}
+
+pub fn process(ctx: Context<ApproveAdminCached>, _: String) -> Result<()> {
+    check_context(&ctx)?;
+
+    let configuration = &mut ctx.accounts.configuration.load_mut()?;
+
+    msg!(
+        "old admin {} new admin {}",
+        configuration.admin,
+        configuration.admin_cached
+    );
+
+    configuration.admin = configuration.admin_cached;
+
+    Ok(())
+}

--- a/programs/scope/src/handlers/handler_approve_admin_cached.rs
+++ b/programs/scope/src/handlers/handler_approve_admin_cached.rs
@@ -11,15 +11,16 @@ pub struct ApproveAdminCached<'info> {
     pub configuration: AccountLoader<'info, crate::Configuration>,
 }
 
-pub fn process(ctx: Context<ApproveAdminCached>, _: String) -> Result<()> {
+pub fn process(ctx: Context<ApproveAdminCached>, feed_name: String) -> Result<()> {
     check_context(&ctx)?;
 
     let configuration = &mut ctx.accounts.configuration.load_mut()?;
 
     msg!(
-        "old admin {} new admin {}",
+        "old admin {} new admin {}, feed_name {}",
         configuration.admin,
-        configuration.admin_cached
+        configuration.admin_cached,
+        feed_name
     );
 
     configuration.admin = configuration.admin_cached;

--- a/programs/scope/src/handlers/handler_initialize.rs
+++ b/programs/scope/src/handlers/handler_initialize.rs
@@ -49,6 +49,7 @@ pub fn process(ctx: Context<Initialize>, _: String) -> Result<()> {
     configuration.oracle_mappings = oracle_pbk;
     configuration.oracle_prices = prices_pbk;
     configuration.oracle_twaps = twaps_pbk;
+    configuration.admin_cached = Pubkey::default();
 
     // Initialize oracle twap account
     let mut oracle_twaps = ctx.accounts.oracle_twaps.load_init()?;

--- a/programs/scope/src/handlers/handler_set_admin_cached.rs
+++ b/programs/scope/src/handlers/handler_set_admin_cached.rs
@@ -1,0 +1,22 @@
+use anchor_lang::{prelude::*, Accounts};
+
+use crate::oracles::check_context;
+
+#[derive(Accounts)]
+#[instruction(new_admin: Pubkey, feed_name: String)]
+pub struct SetAdminCached<'info> {
+    admin: Signer<'info>,
+
+    #[account(mut, seeds = [b"conf", feed_name.as_bytes()], bump, has_one = admin)]
+    pub configuration: AccountLoader<'info, crate::Configuration>,
+}
+
+pub fn process(ctx: Context<SetAdminCached>, new_admin: Pubkey, _: String) -> Result<()> {
+    check_context(&ctx)?;
+
+    let configuration = &mut ctx.accounts.configuration.load_mut()?;
+
+    configuration.admin_cached = new_admin;
+
+    Ok(())
+}

--- a/programs/scope/src/handlers/handler_set_admin_cached.rs
+++ b/programs/scope/src/handlers/handler_set_admin_cached.rs
@@ -11,8 +11,14 @@ pub struct SetAdminCached<'info> {
     pub configuration: AccountLoader<'info, crate::Configuration>,
 }
 
-pub fn process(ctx: Context<SetAdminCached>, new_admin: Pubkey, _: String) -> Result<()> {
+pub fn process(ctx: Context<SetAdminCached>, new_admin: Pubkey, feed_name: String) -> Result<()> {
     check_context(&ctx)?;
+
+    msg!(
+        "setting admin_cached to {} feed_name {}",
+        new_admin,
+        feed_name
+    );
 
     let configuration = &mut ctx.accounts.configuration.load_mut()?;
 

--- a/programs/scope/src/handlers/mod.rs
+++ b/programs/scope/src/handlers/mod.rs
@@ -1,11 +1,15 @@
+pub mod handler_approve_admin_cached;
 pub mod handler_initialize;
 pub mod handler_refresh_prices;
 pub mod handler_reset_twap;
+pub mod handler_set_admin_cached;
 pub mod handler_update_mapping;
 pub mod handler_update_token_metadata;
 
+pub use handler_approve_admin_cached::*;
 pub use handler_initialize::*;
 pub use handler_refresh_prices::*;
 pub use handler_reset_twap::*;
+pub use handler_set_admin_cached::*;
 pub use handler_update_mapping::*;
 pub use handler_update_token_metadata::*;

--- a/programs/scope/src/lib.rs
+++ b/programs/scope/src/lib.rs
@@ -102,6 +102,24 @@ pub mod scope {
             .map_err(|_| ScopeError::OutOfRangeIntegralConversion)?;
         handler_update_token_metadata::process(ctx, index, mode, value, feed_name)
     }
+
+    pub fn set_admin_cached(
+        ctx: Context<SetAdminCached>,
+        new_admin: Pubkey,
+        feed_name: String,
+    ) -> Result<()> {
+        msg!(
+            "setting admin_cached to {} feed_name {}",
+            new_admin,
+            feed_name
+        );
+        handler_set_admin_cached::process(ctx, new_admin, feed_name)
+    }
+
+    pub fn approve_admin_cached(ctx: Context<ApproveAdminCached>, feed_name: String) -> Result<()> {
+        msg!("setting admin to admin_cached for feed_name {}", feed_name);
+        handler_approve_admin_cached::process(ctx, feed_name)
+    }
 }
 
 #[zero_copy]
@@ -238,7 +256,8 @@ pub struct Configuration {
     pub oracle_prices: Pubkey,
     pub tokens_metadata: Pubkey,
     pub oracle_twaps: Pubkey,
-    _padding: [u64; 1259],
+    pub admin_cached: Pubkey,
+    _padding: [u64; 1255],
 }
 
 #[derive(TryFromPrimitive, PartialEq, Eq, Clone, Copy, Debug)]

--- a/programs/scope/src/lib.rs
+++ b/programs/scope/src/lib.rs
@@ -108,16 +108,10 @@ pub mod scope {
         new_admin: Pubkey,
         feed_name: String,
     ) -> Result<()> {
-        msg!(
-            "setting admin_cached to {} feed_name {}",
-            new_admin,
-            feed_name
-        );
         handler_set_admin_cached::process(ctx, new_admin, feed_name)
     }
 
     pub fn approve_admin_cached(ctx: Context<ApproveAdminCached>, feed_name: String) -> Result<()> {
-        msg!("setting admin to admin_cached for feed_name {}", feed_name);
         handler_approve_admin_cached::process(ctx, feed_name)
     }
 }

--- a/programs/scope/tests/common/setup.rs
+++ b/programs/scope/tests/common/setup.rs
@@ -1,5 +1,6 @@
-use anchor_lang::prelude::Pubkey;
-use scope::{OracleMappings, OraclePrices, OracleTwaps, TokenMetadatas};
+use anchor_lang::{prelude::Pubkey, InstructionData, ToAccountMetas};
+use scope::{accounts::Initialize, OracleMappings, OraclePrices, OracleTwaps, TokenMetadatas};
+use solana_program::instruction::Instruction;
 use solana_program_test::ProgramTest;
 use solana_sdk::{
     account::Account, commitment_config::CommitmentLevel, signature::Keypair, signer::Signer,
@@ -7,7 +8,10 @@ use solana_sdk::{
 };
 use types::TestContext;
 
-use super::{types::ScopeZeroCopyAccounts, *};
+use super::{
+    types::{ScopeFeedDefinition, ScopeZeroCopyAccounts},
+    *,
+};
 
 pub async fn new_keypair(ctx: &mut TestContext, min_lamports: u64) -> Keypair {
     let account = Keypair::new();
@@ -97,4 +101,45 @@ impl ScopeZeroCopyAccounts {
             ),
         )
     }
+}
+
+pub async fn setup_scope_feed() -> (TestContext, ScopeFeedDefinition) {
+    let mut test_program = runner::program();
+    let admin = funded_kp(&mut test_program, 100000000);
+    let zero_copy_accounts = types::ScopeZeroCopyAccounts::new();
+    zero_copy_accounts.add_accounts(&mut test_program);
+    let mut ctx = runner::start(test_program, admin, Keypair::new()).await;
+    let (configuration_acc, _) =
+        Pubkey::find_program_address(&[b"conf", DEFAULT_FEED_NAME.as_bytes()], &scope::id());
+    let accounts = Initialize {
+        admin: ctx.admin.pubkey(),
+        system_program: solana_program::system_program::id(),
+        configuration: configuration_acc,
+        oracle_prices: zero_copy_accounts.prices.pubkey(),
+        oracle_mappings: zero_copy_accounts.mapping.pubkey(),
+        token_metadatas: zero_copy_accounts.token_metadatas.pubkey(),
+        oracle_twaps: zero_copy_accounts.oracle_twaps.pubkey(),
+    };
+    let args = scope::instruction::Initialize {
+        feed_name: DEFAULT_FEED_NAME.to_string(),
+    };
+
+    let ix = Instruction {
+        program_id: scope::id(),
+        accounts: accounts.to_account_metas(None),
+        data: args.data(),
+    };
+
+    ctx.send_transaction(&[ix]).await.unwrap();
+
+    (
+        ctx,
+        ScopeFeedDefinition {
+            feed_name: DEFAULT_FEED_NAME.to_string(),
+            conf: configuration_acc,
+            mapping: zero_copy_accounts.mapping.pubkey(),
+            prices: zero_copy_accounts.prices.pubkey(),
+            twaps: zero_copy_accounts.oracle_twaps.pubkey(),
+        },
+    )
 }

--- a/programs/scope/tests/tests_security_set_and_approve_admin.rs
+++ b/programs/scope/tests/tests_security_set_and_approve_admin.rs
@@ -1,0 +1,78 @@
+mod common;
+
+use scope::Configuration;
+use solana_program_test::tokio;
+use solana_sdk::signer::Signer;
+
+use crate::common::{
+    operations::approve_admin_cached,
+    operations::set_admin_cached,
+    setup::{new_keypair, setup_scope_feed},
+    utils::map_anchor_error,
+    utils::AnchorErrorCode,
+};
+// - [x] Set with wrong admin
+// - [x] Approve with wrong admin_cached
+
+#[tokio::test]
+async fn test_working_set_and_approve_admin_cached() {
+    let (mut ctx, scope_feed_definition) = setup_scope_feed().await;
+
+    let admin_cached = new_keypair(&mut ctx, 100000000).await;
+
+    set_admin_cached(&mut ctx, &scope_feed_definition, &admin_cached.pubkey())
+        .await
+        .unwrap();
+
+    let config_state = ctx
+        .get_anchor_account::<Configuration>(&scope_feed_definition.conf)
+        .await
+        .unwrap();
+
+    assert_eq!(config_state.admin_cached, admin_cached.pubkey());
+    assert_eq!(config_state.admin, ctx.admin.pubkey());
+
+    approve_admin_cached(&mut ctx, &scope_feed_definition, &admin_cached)
+        .await
+        .unwrap();
+
+    let config_state = ctx
+        .get_anchor_account::<Configuration>(&scope_feed_definition.conf)
+        .await
+        .unwrap();
+
+    assert_eq!(config_state.admin, admin_cached.pubkey());
+}
+
+// Set with wrong admin
+#[tokio::test]
+async fn test_security_set_admin_cached() {
+    let (mut ctx, scope_feed_definition) = setup_scope_feed().await;
+
+    let admin_cached = new_keypair(&mut ctx, 100000000).await;
+    let admin_cached_pk = admin_cached.pubkey();
+
+    ctx.admin = admin_cached;
+
+    let res = set_admin_cached(&mut ctx, &scope_feed_definition, &admin_cached_pk).await;
+
+    assert_eq!(map_anchor_error(res), AnchorErrorCode::ConstraintHasOne);
+}
+
+// Approve with wrong admin_cached
+#[tokio::test]
+async fn test_security_approve_admin_cached() {
+    let (mut ctx, scope_feed_definition) = setup_scope_feed().await;
+
+    let admin_cached = new_keypair(&mut ctx, 100000000).await;
+
+    set_admin_cached(&mut ctx, &scope_feed_definition, &admin_cached.pubkey())
+        .await
+        .unwrap();
+
+    let wrong_admin = new_keypair(&mut ctx, 100000000).await;
+
+    let res = approve_admin_cached(&mut ctx, &scope_feed_definition, &wrong_admin).await;
+
+    assert_eq!(map_anchor_error(res), AnchorErrorCode::ConstraintHasOne);
+}


### PR DESCRIPTION
This adds 2 new instructions:
1. to set admin_cached, a new field in the `Configuration` state
2. to approve admin_cached which sets the admin as the current admin_ached

Security tests were added and CLI commands were also added, being able to either execute or just print the base64/base58 VersionedTransaction message.

- [x] The CLI has been tested with the local setup and worked as expected.