### PR TITLE
ScopeTwap now track the number of samples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2162,6 +2162,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "intbits"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5170c2c8ecda29c1bccb9d95ccbe107bc75fa084dc0c9c6087e719f9d46330e5"
+
+[[package]]
 name = "io-lifetimes"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2561,7 +2567,7 @@ version = "3.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba8ee05284d79b367ae8966d558e1a305a781fc80c9df51f37775169117ba64f"
 dependencies = [
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "num-derive 0.3.3",
  "num-traits",
  "solana-program",
@@ -3979,6 +3985,7 @@ dependencies = [
  "bytemuck",
  "cfg-if",
  "decimal-wad",
+ "intbits",
  "jup-perp-itf",
  "num_enum 0.7.1",
  "proptest",

--- a/programs/scope/Cargo.toml
+++ b/programs/scope/Cargo.toml
@@ -57,6 +57,7 @@ raydium-amm-v3 = { git = "https://github.com/raydium-io/raydium-clmm", features 
     "cpi",
 ] }
 jup-perp-itf = { path = "../jup-perp-itf", features = ["cpi"] }
+intbits = "0.2.0"
 
 [dev-dependencies]
 async-recursion = "1.0.5"

--- a/programs/scope/src/lib.rs
+++ b/programs/scope/src/lib.rs
@@ -164,13 +164,6 @@ pub enum EmaType {
     Ema1h,
 }
 
-/// The sample tracker is a 64 bit number where each bit represents a point in time.
-/// We only track one point per time slot. The time slot being the ema_period / 64.
-/// The bit is set to 1 if there is a sample at that point in time slot.
-#[derive(bytemuck::Zeroable, bytemuck::Pod, Debug, Eq, PartialEq, Clone, Copy, Default)]
-#[repr(transparent)]
-pub struct EmaTracker(pub u64);
-
 #[zero_copy]
 #[derive(Debug, Eq, PartialEq)]
 pub struct EmaTwap {
@@ -178,7 +171,8 @@ pub struct EmaTwap {
     pub last_update_unix_timestamp: u64,
 
     pub current_ema_1h: u128,
-    pub updates_tracker_1h: EmaTracker,
+    /// The sample tracker is a 64 bit number where each bit represents a point in time.
+    pub updates_tracker_1h: u64,
     pub padding_0: u64,
 
     pub padding_1: [u128; 39],
@@ -190,7 +184,7 @@ impl Default for EmaTwap {
             current_ema_1h: 0,
             last_update_slot: 0,
             last_update_unix_timestamp: 0,
-            updates_tracker_1h: EmaTracker::default(),
+            updates_tracker_1h: 0,
             padding_0: 0,
             padding_1: [0_u128; 39],
         }

--- a/programs/scope/src/oracles/mod.rs
+++ b/programs/scope/src/oracles/mod.rs
@@ -160,7 +160,7 @@ where
         OracleType::JupiterLpFetch => {
             jupiter_lp::get_price_no_recompute(base_account, clock, extra_accounts)
         }
-        OracleType::ScopeTwap => twap::get_price(oracle_mappings, oracle_twaps, index),
+        OracleType::ScopeTwap => twap::get_price(oracle_mappings, oracle_twaps, index, clock),
         OracleType::DeprecatedPlaceholder => {
             panic!("DeprecatedPlaceholder is not a valid oracle type")
         }

--- a/programs/scope/src/oracles/twap.rs
+++ b/programs/scope/src/oracles/twap.rs
@@ -1,11 +1,17 @@
-use crate::ScopeError;
+use std::cmp::Ordering;
+
 use crate::ScopeError::PriceAccountNotExpected;
 use crate::{DatedPrice, OracleMappings, OracleTwaps, Price};
+use crate::{EmaTracker, ScopeError};
 use anchor_lang::prelude::*;
+use intbits::Bits;
 
 use self::utils::{reset_ema_twap, update_ema_twap};
 
 const EMA_1H_DURATION_SECONDS: u64 = 60 * 60;
+const MIN_SAMPLES_IN_PERIOD: u32 = 10;
+const NUM_SUB_PERIODS: usize = 3;
+const MIN_SAMPLES_IN_FIRST_AND_LAST_PERIOD: u32 = 1;
 
 pub fn validate_price_account(account: &AccountInfo) -> Result<()> {
     if account.key().eq(&crate::id()) {
@@ -50,6 +56,7 @@ pub fn get_price(
     oracle_mappings: &OracleMappings,
     oracle_twaps: &OracleTwaps,
     token: usize,
+    clock: &Clock,
 ) -> Result<DatedPrice> {
     let source_index = usize::from(oracle_mappings.twap_source[token]);
     msg!("Get twap price at index {source_index} for tk {token}",);
@@ -58,6 +65,10 @@ pub fn get_price(
         .twaps
         .get(source_index)
         .ok_or(ScopeError::TwapSourceIndexOutOfRange)?;
+
+    let current_ts = clock.unix_timestamp.try_into().unwrap();
+    utils::validate_ema(twap, current_ts)?;
+
     Ok(twap.as_dated_price(source_index.try_into().unwrap()))
 }
 
@@ -128,6 +139,11 @@ mod utils {
                     .map_err(|_| ScopeError::IntegerOverflow)?;
             }
 
+            twap.updates_tracker_1h.update_tracker(
+                EMA_1H_DURATION_SECONDS,
+                price_ts,
+                twap.last_update_unix_timestamp,
+            );
             twap.last_update_slot = price_slot;
             twap.last_update_unix_timestamp = price_ts;
         }
@@ -138,6 +154,154 @@ mod utils {
         twap.current_ema_1h = Decimal::from(price).to_scaled_val().unwrap();
         twap.last_update_slot = price_slot;
         twap.last_update_unix_timestamp = price_ts;
+        twap.updates_tracker_1h = EmaTracker::default();
+    }
+
+    pub(super) fn validate_ema(twap: &EmaTwap, current_ts: u64) -> ScopeResult<()> {
+        let mut tracker = twap.updates_tracker_1h;
+        tracker.erase_old_samples(
+            EMA_1H_DURATION_SECONDS,
+            current_ts,
+            twap.last_update_unix_timestamp,
+        );
+
+        if tracker.get_samples_count() < MIN_SAMPLES_IN_PERIOD {
+            return Err(ScopeError::TwapNotEnoughSamplesInPeriod);
+        }
+
+        let samples_count_per_subperiods = tracker
+            .get_samples_count_per_subperiods::<NUM_SUB_PERIODS>(
+                EMA_1H_DURATION_SECONDS,
+                twap.last_update_unix_timestamp,
+            );
+
+        if samples_count_per_subperiods[0] < MIN_SAMPLES_IN_FIRST_AND_LAST_PERIOD
+            || samples_count_per_subperiods[NUM_SUB_PERIODS - 1]
+                < MIN_SAMPLES_IN_FIRST_AND_LAST_PERIOD
+        {
+            return Err(ScopeError::TwapNotEnoughSamplesInPeriod);
+        }
+
+        Ok(())
+    }
+}
+
+impl EmaTracker {
+    const NB_POINTS: u64 = u64::N_BITS as u64;
+    /// Convert a timestamp to a point in the sample tracker
+    const fn ts_to_point(ts: u64, ema_period: u64) -> u64 {
+        assert!(
+            ema_period >= Self::NB_POINTS,
+            "EMA period must be bigger than 64 seconds"
+        );
+        // point_window_size = ema_period / 64
+        // points_since_epoch = ts / point_window_size
+        // point_index = points_since_epoch % 64
+        (ts * Self::NB_POINTS / ema_period) % Self::NB_POINTS
+    }
+
+    /// Erase the sample tracker points that are older than the ema_period.
+    pub(super) fn erase_old_samples(
+        &mut self,
+        ema_period: u64,
+        current_update_ts: u64,
+        last_update_ts: u64,
+    ) {
+        assert!(
+            current_update_ts >= last_update_ts,
+            "current_update_ts must be bigger than last_update_ts"
+        );
+        let sample_tracker = &mut self.0;
+
+        let ts_to_point = |ts| Self::ts_to_point(ts, ema_period);
+
+        let current_point = ts_to_point(current_update_ts);
+        // 1. Reset all points up to the current one if needed.
+        if last_update_ts + ema_period <= current_update_ts {
+            // Reset all points
+            *sample_tracker = 0;
+        } else {
+            let last_update_point = ts_to_point(last_update_ts);
+            if last_update_point == current_point {
+                // Nothing to reset
+                return;
+            }
+
+            let first_point_to_clean = last_update_point + 1; // +1 because we want to reset the point after the last one we updated
+            let last_point_to_clean = current_point;
+
+            match first_point_to_clean.cmp(&last_point_to_clean) {
+                Ordering::Equal => {
+                    // Nothing to reset
+                }
+                Ordering::Less => {
+                    // Reset all points between the first and the last one
+                    sample_tracker.set_bits(first_point_to_clean..last_point_to_clean, 0);
+                }
+                Ordering::Greater => {
+                    sample_tracker.set_bits(first_point_to_clean..Self::NB_POINTS, 0);
+                    sample_tracker.set_bits(0..last_point_to_clean, 0);
+                }
+            }
+        }
+    }
+
+    /// Track updates to the EMA
+    pub(super) fn update_tracker(
+        &mut self,
+        ema_period: u64,
+        current_update_ts: u64,
+        last_update_ts: u64,
+    ) {
+        // 1. Reset all points up to the current one if needed.
+        self.erase_old_samples(ema_period, current_update_ts, last_update_ts);
+
+        // 2. Update the current point.
+        let current_point = Self::ts_to_point(current_update_ts, ema_period);
+        self.0.set_bit(current_point, true);
+    }
+
+    /// Get the number of samples in the last ema_period.
+    pub(super) fn get_samples_count(&self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// Get the number of samples per each sub-period of the last ema_period.
+    /// The number of sub-periods is defined by the const generic parameter N.
+    /// The returned array contains the number of samples in each sub-period sorted from the oldest to the newest.
+    pub(super) fn get_samples_count_per_subperiods<const N: usize>(
+        &self,
+        ema_period: u64,
+        current_ts: u64,
+    ) -> [u32; N] {
+        // Sort the points so that the oldest one is the first one.
+        let unsorted_points = self.0;
+        let current_point = Self::ts_to_point(current_ts, ema_period);
+        let pivot_point = (current_point + 1) % Self::NB_POINTS;
+        let jonction_point = Self::NB_POINTS - pivot_point;
+        let points_oldest = unsorted_points.bits(pivot_point..Self::NB_POINTS);
+        let points_newest = unsorted_points.bits(0..pivot_point);
+        let sorted_points = points_oldest.with_bits(jonction_point..Self::NB_POINTS, points_newest);
+
+        // Count the number of samples in each sub-period
+        let sub_period_size = Self::NB_POINTS / N as u64;
+        let mut counts = [0; N];
+
+        let count_in_period = |start_point: u64, end_point: u64| -> u32 {
+            sorted_points.bits(start_point..end_point).count_ones()
+        };
+
+        let mut start_period_point = 0;
+        for count in counts.iter_mut().take(N - 1) {
+            let end_period_point = start_period_point + sub_period_size;
+            *count = count_in_period(start_period_point, end_period_point);
+            start_period_point = end_period_point;
+        }
+
+        // The last sub-period might be bigger than the others
+        counts[N - 1] = count_in_period(start_period_point, Self::NB_POINTS);
+
+        counts
     }
 }
 
@@ -189,7 +353,7 @@ mod tests_reset_twap {
             current_ema_1h: 1234_u128,
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price = Price {
@@ -294,7 +458,7 @@ mod tests_update_ema_twap {
             current_ema_1h: Decimal::from(100_000).to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price = Price {
@@ -320,7 +484,7 @@ mod tests_update_ema_twap {
             current_ema_1h: Decimal::from(1).to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(1).into();
@@ -343,7 +507,7 @@ mod tests_update_ema_twap {
             current_ema_1h: Decimal::from(125_000_000).to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(125_000_000).into();
@@ -367,7 +531,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(120_000).into();
@@ -389,7 +553,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(120_000).into();
@@ -413,7 +577,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let mut twap_with_late_sample = twap_with_early_sample;
@@ -456,7 +620,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let mut price_value = 10_000;
@@ -490,7 +654,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(20_000).into();
@@ -512,7 +676,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let test_price: Price = Decimal::from(120_000).into();
@@ -535,7 +699,7 @@ mod tests_update_ema_twap {
             current_ema_1h: initial_ema.to_scaled_val().unwrap(),
             last_update_slot: 3,
             last_update_unix_timestamp: 50,
-            padding: [0_u128; 40],
+            ..Default::default()
         };
 
         let mut price_value = 3_000;
@@ -560,5 +724,100 @@ mod tests_update_ema_twap {
 
             previous_twap = twap;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests_samples_tracker {
+    use super::EmaTracker;
+    use test_case::test_case;
+
+    #[derive(Debug, Clone, Copy)]
+    struct TrackerTester {
+        tracker: EmaTracker,
+        ema_period: u64,
+        last_update_ts: u64,
+    }
+
+    impl TrackerTester {
+        fn add_update(&mut self, ts: u64) {
+            self.tracker
+                .update_tracker(self.ema_period, ts, self.last_update_ts);
+            self.last_update_ts = ts;
+        }
+
+        fn get_samples_count(&self, ts: u64) -> u32 {
+            let mut cpy = self.tracker;
+            cpy.erase_old_samples(self.ema_period, ts, self.last_update_ts);
+            cpy.get_samples_count()
+        }
+
+        fn new(ema_period: u64) -> Self {
+            Self {
+                tracker: EmaTracker::default(),
+                ema_period,
+                last_update_ts: 0,
+            }
+        }
+
+        fn get_samples_count_per_subperiods<const N: usize>(&self, ts: u64) -> [u32; N] {
+            let mut cpy = self.tracker;
+            cpy.erase_old_samples(self.ema_period, ts, self.last_update_ts);
+            cpy.get_samples_count_per_subperiods::<N>(self.ema_period, ts)
+        }
+    }
+
+    #[test_case(64, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] => 11)]
+    #[test_case(64, &[63, 68] => 2)]
+    #[test_case(64, &[1, 2, 5, 64, 68, 124] => 3)]
+    #[test_case(64*60, &[60, 120, 240, 2400] => 4)]
+    #[test_case(60*60, &[60, 120, 240, 2400] => 4)]
+    #[test_case(60*60, &[60, 90, 120, 240, 245, 2400] => 4)]
+    #[test_case(60*60, &[30, 120, 240] => 3)]
+    #[test_case(60*60, &[30, 120, 240, 3631] => 3)]
+    #[test_case(60*60, &[30, 120, 240, 3931] => 1)]
+    fn test_tracker_count(ema_period_s: u64, samples_ts: &[u64]) -> u32 {
+        let mut tester = TrackerTester::new(ema_period_s);
+        for ts in samples_ts {
+            tester.add_update(*ts);
+        }
+        tester.get_samples_count(*samples_ts.last().unwrap())
+    }
+
+    #[test]
+    fn test_tracker_overrun() {
+        let mut tester = TrackerTester::new(64);
+        for ts in 0..100 {
+            tester.add_update(ts);
+        }
+        assert_eq!(tester.get_samples_count(100), 64);
+        assert_eq!(tester.get_samples_count(200), 0);
+    }
+
+    fn test_tracker_subperiod_count_helper<const N: usize>(
+        ema_period_s: u64,
+        samples_ts: &[u64],
+    ) -> [u32; N] {
+        let mut tester = TrackerTester::new(ema_period_s);
+        for ts in samples_ts {
+            tester.add_update(*ts);
+        }
+        tester.get_samples_count_per_subperiods::<N>(*samples_ts.last().unwrap())
+    }
+
+    #[test_case(64, &[0, 21, 42, 63] => [1, 1, 1, 1])]
+    #[test_case(64, &[0, 21, 42, 60, 63] => [1, 1, 1, 2])]
+    #[test_case(64, &[0, 63] => [1, 0, 0, 1])]
+    #[test_case(64, &[0, 2, 3, 21, 25, 28, 30, 42, 60, 63] => [3, 4, 1, 2])]
+    #[test_case(64, &[0, 2, 3, 21, 25, 28, 30, 42, 114, 115] => [0, 0, 0, 2])]
+    fn test_tracker_subperiod_count_4(ema_period_s: u64, samples_ts: &[u64]) -> [u32; 4] {
+        test_tracker_subperiod_count_helper(ema_period_s, samples_ts)
+    }
+
+    #[test_case(60*60, &[0, 21*60, 42*60] => [1, 1, 1])]
+    #[test_case(60*60, &[10*60, 15*60, 25*60, 30*60, 60*60] => [2, 2, 1])]
+    #[test_case(60*60, &[0, 10*60, 15*60, 25*60, 30*60, 60*60, 69*60] => [3, 1, 2])]
+    fn test_tracker_subperiod_count_3(ema_period_s: u64, samples_ts: &[u64]) -> [u32; 3] {
+        test_tracker_subperiod_count_helper(ema_period_s, samples_ts)
     }
 }

--- a/programs/scope/src/oracles/twap.rs
+++ b/programs/scope/src/oracles/twap.rs
@@ -247,7 +247,7 @@ impl EmaTracker {
                 return;
             }
 
-            let first_point_to_clean = last_update_point + 1; // +1 because we want to reset the point after the last one we updated
+            let first_point_to_clean = (last_update_point + 1) % Self::NB_POINTS; // +1 because we want to reset the point after the last one we updated
             let last_point_to_clean = current_point;
 
             match first_point_to_clean.cmp(&last_point_to_clean) {
@@ -256,11 +256,11 @@ impl EmaTracker {
                 }
                 Ordering::Less => {
                     // Reset all points between the first and the last one
-                    sample_tracker.set_bits(first_point_to_clean..last_point_to_clean, 0);
+                    sample_tracker.set_bits(first_point_to_clean..=last_point_to_clean, 0);
                 }
                 Ordering::Greater => {
                     sample_tracker.set_bits(first_point_to_clean..Self::NB_POINTS, 0);
-                    sample_tracker.set_bits(0..last_point_to_clean, 0);
+                    sample_tracker.set_bits(0..=last_point_to_clean, 0);
                 }
             }
         }
@@ -790,6 +790,7 @@ mod tests_samples_tracker {
     #[test_case(64, &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11] => 11)]
     #[test_case(64, &[63, 68] => 2)]
     #[test_case(64, &[1, 2, 5, 64, 68, 124] => 3)]
+    #[test_case(64, &[0, 2, 5, 63, 66, 67] => 4)]
     #[test_case(64*60, &[60, 120, 240, 2400] => 4)]
     #[test_case(60*60, &[60, 120, 240, 2400] => 4)]
     #[test_case(60*60, &[60, 90, 120, 240, 245, 2400] => 4)]

--- a/programs/scope/tests/common/operations.rs
+++ b/programs/scope/tests/common/operations.rs
@@ -76,7 +76,7 @@ pub async fn set_admin_cached(
     .to_account_metas(None);
 
     let args = scope::instruction::SetAdminCached {
-        new_admin: admin_cached.clone(),
+        new_admin: *admin_cached,
         feed_name: feed.feed_name.clone(),
     };
 


### PR DESCRIPTION
ScopeTwap (1h) is now considered invalid if not enough samples have been taken in the past hour:

- Need at least 10 points in the past hour
- Need at least 1 point in the first 20 minutes of the period
- Need at least 1 point in the last 20 minutes of the period

The implementation aims to be scalable and work with the same principles with twap of different periods. For this, the EMA period is divided into 64 time windows, and only one sample is counted for each. This means for the 1-hour twap that if two price refreshes happen in less than 60*60/64 = 56 seconds, then only one sample will be counted.