### PR TITLE
Bot improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ init: $(SCOPE_CLI)
 
 update-mapping: $(SCOPE_CLI)
 >@ if [ $(CLUSTER) = "mainnet" ]; then\
-      RUST_BACKTRACE=1 RUST_LOG="scope_client=trace,scope=trace" cargo run -p scope-cli -- --cluster $(URL) --multisig $(SCOPE_MULTISIG_AUTH) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) upload --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json;\
+      RUST_BACKTRACE=1 RUST_LOG="scope_client=info" cargo run -p scope-cli -- --cluster $(URL) --multisig $(SCOPE_MULTISIG_AUTH) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) upload --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json;\
   else\
       RUST_BACKTRACE=1 RUST_LOG="scope_client=trace,scope=trace" cargo run -p scope-cli -- --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) upload --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json;\
   fi

--- a/Makefile
+++ b/Makefile
@@ -186,11 +186,10 @@ update-mapping: $(SCOPE_CLI)
   fi
 
 crank: $(SCOPE_CLI)
-> if [ -f ./configs/$(CLUSTER)/$(FEED_NAME).json ]; then\
-       cargo run -p scope-cli -- --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) --log-timestamps crank --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json;\
-   else\
-       cargo run -p scope-cli -- --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) --log-timestamps crank;\
-   fi
+> cargo run -p scope-cli -- --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) --log-timestamps crank
+
+crank-with-conf: $(SCOPE_CLI)
+> cargo run -p scope-cli -- --cluster $(URL) --keypair $(OWNER_KEYPAIR) --program-id $(SCOPE_PROGRAM_ID) --price-feed $(FEED_NAME) --log-timestamps crank --mapping ./configs/$(CLUSTER)/$(FEED_NAME).json
 
 get-prices: $(SCOPE_CLI)
 >@ if [ -f ./configs/$(CLUSTER)/$(FEED_NAME).json ]; then\

--- a/off_chain/scope-cli/src/main.rs
+++ b/off_chain/scope-cli/src/main.rs
@@ -1,3 +1,4 @@
+use std::fmt::Debug;
 use std::{
     io::IsTerminal,
     ops::Neg,
@@ -23,7 +24,7 @@ use tracing_subscriber::EnvFilter;
 
 mod web;
 
-#[derive(Parser, Debug)]
+#[derive(Parser)]
 #[clap(author, version, about, long_about = None)]
 struct Args {
     /// Connect to solana validator
@@ -58,6 +59,26 @@ struct Args {
     /// Subcommand to execute
     #[clap(subcommand)]
     action: Actions,
+}
+
+impl Debug for Args {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let cluster_str = if matches!(self.cluster, Cluster::Custom(..)) {
+            "Custom *****".to_owned()
+        } else {
+            format!("{:?}", self.cluster)
+        };
+        f.debug_struct("Args")
+            .field("cluster", &cluster_str)
+            .field("keypair", &self.keypair)
+            .field("program_id", &self.program_id)
+            .field("price_feed", &self.price_feed)
+            .field("multisig", &self.multisig)
+            .field("json", &self.json)
+            .field("log_timestamps", &self.log_timestamps)
+            .field("action", &self.action)
+            .finish()
+    }
 }
 
 #[derive(Debug, Subcommand)]

--- a/off_chain/scope-cli/src/main.rs
+++ b/off_chain/scope-cli/src/main.rs
@@ -410,13 +410,6 @@ async fn crank<T: AsyncClient, S: Signer>(
             last_mapping_refresh = Instant::now();
         }
 
-        if last_print.elapsed() > print_period {
-            let current_slot = get_clock(scope.get_rpc()).await.unwrap_or_default().slot;
-            info!(current_slot);
-            let _ = scope.log_prices(current_slot).await;
-            last_print = Instant::now();
-        }
-
         if let Err(e) = scope.refresh_old_prices().await {
             warn!("Error while refreshing prices {:?}", e);
         }
@@ -434,6 +427,13 @@ async fn crank<T: AsyncClient, S: Signer>(
             } else {
                 warn!(%error_log, old_prices=?scope.get_expired_prices().await.unwrap_or_default());
             }
+        }
+
+        if last_print.elapsed() > print_period {
+            let current_slot = get_clock(scope.get_rpc()).await.unwrap_or_default().slot;
+            info!(current_slot);
+            let _ = scope.log_prices(current_slot).await;
+            last_print = Instant::now();
         }
 
         let sleep_ms_from_slots = if shortest_ttl > 0 {

--- a/programs/scope/src/oracles/mod.rs
+++ b/programs/scope/src/oracles/mod.rs
@@ -94,12 +94,12 @@ impl OracleType {
     /// Get the number of compute unit needed to refresh the price of a token
     pub fn get_update_cu_budget(&self) -> u32 {
         match self {
-            OracleType::Pyth => 15_000,
+            OracleType::Pyth => 20_000,
             OracleType::SwitchboardV2 => 30_000,
             OracleType::CToken => 130_000,
             OracleType::SplStake => 20_000,
             OracleType::KToken => 120_000,
-            OracleType::PythEMA => 15_000,
+            OracleType::PythEMA => 20_000,
             OracleType::KTokenToTokenA | OracleType::KTokenToTokenB => 100_000,
             OracleType::MsolStake => 20_000,
             OracleType::JupiterLpFetch => 40_000,
@@ -108,7 +108,7 @@ impl OracleType {
             | OracleType::OrcaWhirlpoolBtoA
             | OracleType::RaydiumAmmV3AtoB
             | OracleType::RaydiumAmmV3BtoA => 20_000,
-            OracleType::JupiterLpCompute => 100_000,
+            OracleType::JupiterLpCompute => 120_000,
             OracleType::DeprecatedPlaceholder1 | OracleType::DeprecatedPlaceholder2 => {
                 panic!("DeprecatedPlaceholder is not a valid oracle type")
             }

--- a/third-party/spl-stake-pool/spl-stake-auto-update.sh
+++ b/third-party/spl-stake-pool/spl-stake-auto-update.sh
@@ -10,3 +10,14 @@ case "$uname" in
     (*) echo 'error: unsupported platform.'; exit 2; ;;
 esac;
 
+case "$uname" in
+    (*Linux*) jq 'to_entries | map(.value) | .[]' ../../configs/mainnet/hubble.json | tail -n +2 | jq 'select(.oracle_type=="SplStake") | .oracle_mapping' | xargs -i bash -c 'spl-stake-pool update --no-merge {}'; ;;
+    (*Darwin*) jq 'to_entries | map(.value) | .[]' ../../configs/mainnet/hubble.json | tail -n +2 | jq 'select(.oracle_type=="SplStake") | .oracle_mapping' | gxargs -i bash -c 'spl-stake-pool update --no-merge {}'; ;;
+    (*) echo 'error: unsupported platform.'; exit 2; ;;
+esac;
+
+case "$uname" in
+    (*Linux*) jq 'to_entries | map(.value) | .[]' ../../configs/mainnet/hubble.json | tail -n +2 | jq 'select(.oracle_type=="SplStake") | .oracle_mapping' | xargs -i bash -c 'spl-stake-pool update {}'; ;;
+    (*Darwin*) jq 'to_entries | map(.value) | .[]' ../../configs/mainnet/hubble.json | tail -n +2 | jq 'select(.oracle_type=="SplStake") | .oracle_mapping' | gxargs -i bash -c 'spl-stake-pool update {}'; ;;
+    (*) echo 'error: unsupported platform.'; exit 2; ;;
+esac;


### PR DESCRIPTION
- Repeat commands for updating spl stake accounts (workaround failures on first attempt)
- `make crank` now use onchain config by default.
- Print all prices in crank after the crank instead of after the sleep (avoid too many "red" prints)
- Increase CU for some types (covers error prints in most cases)
- Don't print custom RPC URL